### PR TITLE
Padding and Normalization: 1.2.1

### DIFF
--- a/.github/workflows/publish-260.yaml
+++ b/.github/workflows/publish-260.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - v1.2.0.260
+    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - v1.2.1.260
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -66,7 +66,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   publish:
-    name: Publish v1.2.0.260 to PyPI
+    name: Publish v1.2.1.260 to PyPI
     needs: build_wheels
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish-270.yaml
+++ b/.github/workflows/publish-270.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - v1.2.0.270
+    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - v1.2.1.270
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -66,7 +66,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   publish:
-    name: Publish v1.2.0.270 to PyPI
+    name: Publish v1.2.1.270 to PyPI
     needs: build_wheels
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish-271.yaml
+++ b/.github/workflows/publish-271.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - v1.2.0.271
+    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - v1.2.1.271
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -66,7 +66,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   publish:
-    name: Publish v1.2.0.271 to PyPI
+    name: Publish v1.2.1.271 to PyPI
     needs: build_wheels
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish-280.yaml
+++ b/.github/workflows/publish-280.yaml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - v1.2.0.280
+    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - v1.2.1.280
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -66,7 +66,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   publish:
-    name: Publish v1.2.0.280 to PyPI
+    name: Publish v1.2.1.280 to PyPI
     needs: build_wheels
     runs-on: ubuntu-latest
     permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast_plaid_rust"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 build = "build.rs"
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 lint:
 	cargo clean
-	uv pip install torch==2.7.0
-	uv run --extra dev pre-commit run --files python/**/**.py
+	uv pip install torch==2.8.0
+	uv run --extra dev pre-commit run --files python/**/**/**.py
 
 install:
 	cargo clean
 	uv pip install torch==2.8.0
-	uv run pip install -e ".[dev]"
+	uv pip install -e ".[dev]"
 
 test:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -42,34 +42,37 @@ pip install fast-plaid
 
 FastPlaid is available in multiple versions to support different PyTorch versions:
 
-| FastPlaid Version | PyTorch Version | Installation Command |
-|-------------------|-----------------|---------------------|
-| 1.2.0.280         | 2.8.0          | `pip install fast-plaid==1.2.0.280` |
-| 1.2.0.271         | 2.7.1          | `pip install fast-plaid==1.2.0.271` |
-| 1.2.0.270         | 2.7.0          | `pip install fast-plaid==1.2.0.270` |
-| 1.2.0.260         | 2.6.0          | `pip install fast-plaid==1.2.0.260` |
+| FastPlaid Version | PyTorch Version | Installation Command                |
+| ----------------- | --------------- | ----------------------------------- |
+| 1.2.1.280         | 2.8.0           | `pip install fast-plaid==1.2.1.280` |
+| 1.2.1.271         | 2.7.1           | `pip install fast-plaid==1.2.1.271` |
+| 1.2.1.270         | 2.7.0           | `pip install fast-plaid==1.2.1.270` |
+| 1.2.1.260         | 2.6.0           | `pip install fast-plaid==1.2.1.260` |
 
 ### Adding FastPlaid as a Dependency
 
 You can add FastPlaid to your project dependencies with version ranges to ensure compatibility:
 
 **For requirements.txt:**
+
 ```
-fast-plaid>=1.2.0.260,<=1.2.0.280
+fast-plaid>=1.2.1.260,<=1.2.1.280
 ```
 
 **For pyproject.toml:**
+
 ```toml
 [project]
 dependencies = [
-    "fast-plaid>=1.2.0.260,<=1.2.0.280"
+    "fast-plaid>=1.2.1.260,<=1.2.1.280"
 ]
 ```
 
 **For setup.py:**
+
 ```python
 install_requires=[
-    "fast-plaid>=1.2.0.260,<=1.2.0.280"
+    "fast-plaid>=1.2.1.260,<=1.2.1.280"
 ]
 ```
 
@@ -330,7 +333,7 @@ The **`create` method** builds the multi-vector index from your document embeddi
 ```python
     def create(
         self,
-        documents_embeddings: list[torch.Tensor],
+        documents_embeddings: list[torch.Tensor] | torch.Tensor,
         kmeans_niters: int = 4,
         max_points_per_centroid: int = 256,
         nbits: int = 4,
@@ -339,9 +342,9 @@ The **`create` method** builds the multi-vector index from your document embeddi
 ```
 
 ```
-documents_embeddings: list[torch.Tensor]
+documents_embeddings: list[torch.Tensor] | torch.Tensor
     A list where each element is a PyTorch tensor representing the multi-vector embedding for a single document.
-    Each document's embedding should have a shape of `(num_tokens, embedding_dimension)`.
+    Each document's embedding should have a shape of `(num_tokens, embedding_dimension)`. Can also be a single tensor of shape `(num_documents, num_tokens, embedding_dimension)`.
 
 kmeans_niters: int = 4 (optional)
     The number of iterations for the K-means algorithm used during index creation.
@@ -371,7 +374,7 @@ The **`update` method** provides an efficient way to add new documents to an exi
 ```python
     def update(
         self,
-        documents_embeddings: list[torch.Tensor],
+        documents_embeddings: list[torch.Tensor] | torch.Tensor,
     ) -> "FastPlaid":
 ```
 
@@ -389,7 +392,7 @@ The **`search` method** lets you query the created index with your query embeddi
 ```python
     def search(
         self,
-        queries_embeddings: torch.Tensor,
+        queries_embeddings: torch.Tensor | list[torch.Tensor],
         top_k: int = 10,
         batch_size: int = 1 << 18,
         n_full_scores: int = 4096,
@@ -400,9 +403,10 @@ The **`search` method** lets you query the created index with your query embeddi
 ```
 
 ```
-queries_embeddings: torch.Tensor
+queries_embeddings: torch.Tensor | list[torch.Tensor]
     A PyTorch tensor representing the multi-vector embeddings of your queries.
     Its shape should be `(num_queries, num_tokens_per_query, embedding_dimension)`.
+    Can also be a list of tensors, each representing a separate query. All tensors in the list must have the same embedding dimension.
 
 top_k: int = 10 (optional)
     The number of top-scoring documents to retrieve for each query.

--- a/ci-260.toml
+++ b/ci-260.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "fast_plaid"
-version = "1.2.0.260"
+version = "1.2.1.260"
 description = "Fast Plaid."
 authors = [
   { name = "Raphael Sourty, LightOn", email = "raphael.sourty@lighton.ai" },
@@ -37,7 +37,7 @@ dev = [
   "pytest >= 7.4.4",
   "ruff >= 0.1.15",
   "pre-commit >= 3.0.0",
-  "pylate >= 1.2.0",
+  "pylate >= 1.2.1",
   "beir>=2.1.0",
   "ranx>=0.3.20",
 ]

--- a/ci-270.toml
+++ b/ci-270.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "fast_plaid"
-version = "1.2.0.270"
+version = "1.2.1.270"
 description = "Fast Plaid."
 authors = [
   { name = "Raphael Sourty, LightOn", email = "raphael.sourty@lighton.ai" },
@@ -37,7 +37,7 @@ dev = [
   "pytest >= 7.4.4",
   "ruff >= 0.1.15",
   "pre-commit >= 3.0.0",
-  "pylate >= 1.2.0",
+  "pylate >= 1.2.1",
   "beir>=2.1.0",
   "ranx>=0.3.20",
 ]

--- a/ci-271.toml
+++ b/ci-271.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "fast_plaid"
-version = "1.2.0.271"
+version = "1.2.1.271"
 description = "Fast Plaid."
 authors = [
   { name = "Raphael Sourty, LightOn", email = "raphael.sourty@lighton.ai" },
@@ -37,7 +37,7 @@ dev = [
   "pytest >= 7.4.4",
   "ruff >= 0.1.15",
   "pre-commit >= 3.0.0",
-  "pylate >= 1.2.0",
+  "pylate >= 1.2.1",
   "beir>=2.1.0",
   "ranx>=0.3.20",
 ]

--- a/ci-280.toml
+++ b/ci-280.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "fast_plaid"
-version = "1.2.0.280"
+version = "1.2.1.280"
 description = "Fast Plaid."
 authors = [
   { name = "Raphael Sourty, LightOn", email = "raphael.sourty@lighton.ai" },
@@ -37,7 +37,7 @@ dev = [
   "pytest >= 7.4.4",
   "ruff >= 0.1.15",
   "pre-commit >= 3.0.0",
-  "pylate >= 1.2.0",
+  "pylate >= 1.2.1",
   "beir>=2.1.0",
   "ranx>=0.3.20",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "fast_plaid"
-version = "1.2.0"
+version = "1.2.1"
 description = "Fast Plaid."
 authors = [
   { name = "Raphael Sourty, LightOn", email = "raphael.sourty@lighton.ai" },

--- a/rust/search/search.rs
+++ b/rust/search/search.rs
@@ -88,7 +88,11 @@ pub fn decompress_residuals(
     let output_contributions_sum = reshaped_gathered_weights + reshaped_centroids;
     let decompressed_embeddings = output_contributions_sum.view([num_embeddings, emb_dim]);
 
-    decompressed_embeddings
+    let norms = decompressed_embeddings
+        .norm_scalaropt_dim(2.0, &[-1], true)
+        .clamp_min(1e-12);
+        
+    decompressed_embeddings / norms
 }
 
 /// Represents the results of a single search query.


### PR DESCRIPTION
This MR improves Fast-Plaid results by l2-normalizing centroids when decompressing them. Also I extended the support for un-padded queries where a batch of queries might have a distinct list of tokens (related to PyLate and ModernColBERT). The queries embeddings will be padded by Fast-Plaid to the longest query within the batch with 0. Solved an error when the dataset is really small related to fast-kmeans: properly set the number of clusters we want to compute.