### PR TITLE
Add compress_only mode to skip IVF construction

### DIFF
--- a/python/fast_plaid/search/fast_plaid.py
+++ b/python/fast_plaid/search/fast_plaid.py
@@ -526,6 +526,7 @@ class FastPlaid:
         use_triton_kmeans: bool | None = None,
         metadata: list[dict[str, Any]] | None = None,
         start_from_scratch: int = 1000,
+        compress_only: bool = False,
     ) -> "FastPlaid":
         """Create and saves the FastPlaid index.
 
@@ -551,6 +552,9 @@ class FastPlaid:
             A list of metadata dictionaries corresponding to the documents.
         start_from_scratch:
             Threshold of documents below which the index is built from scratch.
+        compress_only:
+            If True, skip IVF construction. The index can be used with
+            ``get_embeddings()`` but not ``search()``.
 
         """
         # Exclusive Lock for Modification
@@ -608,6 +612,7 @@ class FastPlaid:
                 centroids=centroids,
                 batch_size=batch_size,
                 seed=seed,
+                compress_only=compress_only,
             )
 
             # Explicit cleanup of create objects
@@ -868,9 +873,7 @@ class FastPlaid:
                     show_progress=(show_progress and i == 0),
                     subset=sub_chunk,
                 )
-                for i, (chunk, sub_chunk) in enumerate(
-                    zip(query_chunks, subset_chunks)
-                )
+                for i, (chunk, sub_chunk) in enumerate(zip(query_chunks, subset_chunks))
             )
             return [item for sublist in results for item in sublist]
 

--- a/python/fast_plaid/search/load.py
+++ b/python/fast_plaid/search/load.py
@@ -264,19 +264,26 @@ def _load_index_tensors_cpu(index_path: str) -> dict[str, Any] | None:
             dtype=torch.float16,
             device=device,
         ),
-        "ivf": _load_small_tensor(
+    }
+
+    ivf_path = os.path.join(index_path, "ivf.npy")
+    ivf_lengths_path = os.path.join(index_path, "ivf_lengths.npy")
+    if os.path.exists(ivf_path) and os.path.exists(ivf_lengths_path):
+        data["ivf"] = _load_small_tensor(
             index_path=index_path,
             name="ivf.npy",
             dtype=torch.int64,
             device=device,
-        ),
-        "ivf_lengths": _load_small_tensor(
+        )
+        data["ivf_lengths"] = _load_small_tensor(
             index_path=index_path,
             name="ivf_lengths.npy",
             dtype=torch.int32,
             device=device,
-        ),
-    }
+        )
+    else:
+        data["ivf"] = None
+        data["ivf_lengths"] = None
 
     all_doc_lens = []
     for i in range(num_chunks):
@@ -330,9 +337,11 @@ def _construct_index_from_tensors(
         If True, keeps large document tensors on CPU to save VRAM.
 
     """
-    gpu_data = {}
+    gpu_data: dict[str, Any] = {}
     for key, val in data.items():
-        if isinstance(val, torch.Tensor):
+        if val is None:
+            gpu_data[key] = None
+        elif isinstance(val, torch.Tensor):
             if low_memory and key in ["doc_codes", "doc_residuals", "doc_lengths"]:
                 gpu_data[key] = val
             else:

--- a/python/fast_plaid/search/update.py
+++ b/python/fast_plaid/search/update.py
@@ -294,6 +294,7 @@ def process_update(
     with open(os.path.join(index_path, "metadata.json")) as f:
         meta = json.load(f)
         num_documents_in_index = meta.get("num_documents", start_from_scratch + 1)
+        compress_only = meta.get("compress_only", False)
 
     num_docs = len(documents_embeddings)
 
@@ -332,6 +333,7 @@ def process_update(
             use_triton_kmeans=use_triton_kmeans,
             metadata=None,
             start_from_scratch=start_from_scratch,
+            compress_only=compress_only,
         )
 
         if len(documents_embeddings) > start_from_scratch and os.path.exists(

--- a/rust/index/create.rs
+++ b/rust/index/create.rs
@@ -212,6 +212,7 @@ pub fn create_index(
     centroids: Tensor,
     batch_size: i64,
     seed: Option<u64>,
+    compress_only: bool,
 ) -> Result<()> {
     let n_docs = documents_embeddings.len();
     let n_chunks = (n_docs as f64 / (batch_size as f64).min(1.0 + n_docs as f64)).ceil() as usize;
@@ -521,38 +522,41 @@ pub fn create_index(
         }
     }
 
-    // Build global IVF
     let total_num_embeddings = current_emb_offset;
-    let all_codes = Tensor::zeros(&[total_num_embeddings as i64], (Kind::Int64, device));
 
-    for chunk_index in 0..n_chunks {
-        let chk_offset_global = chk_emb_offsets[chunk_index];
-        let codes_fpath = Path::new(index_path).join(format!("{}.codes.npy", chunk_index));
-        let codes_from_file = Tensor::read_npy(&codes_fpath)?.to_device(device);
-        let count = codes_from_file.size()[0];
-        all_codes
-            .narrow(0, chk_offset_global as i64, count)
-            .copy_(&codes_from_file);
+    // Build global IVF (skipped in compress_only mode)
+    if !compress_only {
+        let all_codes = Tensor::zeros(&[total_num_embeddings as i64], (Kind::Int64, device));
+
+        for chunk_index in 0..n_chunks {
+            let chk_offset_global = chk_emb_offsets[chunk_index];
+            let codes_fpath = Path::new(index_path).join(format!("{}.codes.npy", chunk_index));
+            let codes_from_file = Tensor::read_npy(&codes_fpath)?.to_device(device);
+            let count = codes_from_file.size()[0];
+            all_codes
+                .narrow(0, chk_offset_global as i64, count)
+                .copy_(&codes_from_file);
+        }
+
+        let (sorted_codes, sorted_indices) = all_codes.sort(0, false);
+        let code_counts = sorted_codes.bincount::<Tensor>(None, est_total_embeddings);
+
+        let (opt_ivf, opt_inverted_file_lengths) =
+            optimize_ivf(&sorted_indices, &code_counts, index_path, device)
+                .context("Failed to optimize IVF")?;
+
+        let opt_ivf_fpath = Path::new(index_path).join("ivf.npy");
+        opt_ivf
+            .to_device(Device::Cpu)
+            .to_kind(Kind::Int64)
+            .write_npy(&opt_ivf_fpath)?;
+
+        let opt_lengths_fpath = Path::new(index_path).join("ivf_lengths.npy");
+        opt_inverted_file_lengths
+            .to_device(Device::Cpu)
+            .to_kind(Kind::Int)
+            .write_npy(&opt_lengths_fpath)?;
     }
-
-    let (sorted_codes, sorted_indices) = all_codes.sort(0, false);
-    let code_counts = sorted_codes.bincount::<Tensor>(None, est_total_embeddings);
-
-    let (opt_ivf, opt_inverted_file_lengths) =
-        optimize_ivf(&sorted_indices, &code_counts, index_path, device)
-            .context("Failed to optimize IVF")?;
-
-    let opt_ivf_fpath = Path::new(index_path).join("ivf.npy");
-    opt_ivf
-        .to_device(Device::Cpu)
-        .to_kind(Kind::Int64)
-        .write_npy(&opt_ivf_fpath)?;
-
-    let opt_lengths_fpath = Path::new(index_path).join("ivf_lengths.npy");
-    opt_inverted_file_lengths
-        .to_device(Device::Cpu)
-        .to_kind(Kind::Int)
-        .write_npy(&opt_lengths_fpath)?;
 
     // Write global metadata
     let final_meta_fpath = Path::new(index_path).join("metadata.json");
@@ -569,6 +573,7 @@ pub fn create_index(
         "num_embeddings": total_num_embeddings,
         "avg_doclen": final_avg_doclen,
         "num_documents": num_documents,
+        "compress_only": compress_only,
     });
 
     serde_json::to_writer_pretty(

--- a/rust/index/update.rs
+++ b/rust/index/update.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use indicatif::{ProgressBar, ProgressIterator};
 use pyo3_tch::PyTensor;
 use serde_json;
@@ -59,6 +59,10 @@ pub fn update_index(
         .context("Missing 'num_partitions' in metadata")?;
 
     let old_total_embeddings_count = main_meta["num_embeddings"].as_i64().unwrap_or(0);
+    let compress_only = main_meta
+        .get("compress_only")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     let embedding_dim = index.codec.centroids.size()[1];
     let num_centroids = index.codec.centroids.size()[0];
@@ -310,127 +314,135 @@ pub fn update_index(
         }
     }
 
-    // Generate new partial IVF
-    let new_codes_flat = Tensor::cat(&new_codes_accumulated, 0).to_device(Device::Cpu);
-    drop(new_codes_accumulated);
-    let new_codes_vec: Vec<i64> = Vec::<i64>::try_from(&new_codes_flat)?;
+    // Generate new partial IVF and merge with old (skipped in compress_only mode)
+    if !compress_only {
+        let new_codes_flat = Tensor::cat(&new_codes_accumulated, 0).to_device(Device::Cpu);
+        let new_codes_vec: Vec<i64> = Vec::<i64>::try_from(&new_codes_flat)?;
 
-    let mut partition_pids_map: HashMap<i64, Vec<i64>> = HashMap::new();
-    let mut pid_counter = old_num_documents;
-    let mut code_idx = 0;
-    for &doc_len in &new_doclens_accumulated {
-        for _ in 0..doc_len {
-            let code = new_codes_vec[code_idx];
-            partition_pids_map
-                .entry(code)
-                .or_insert_with(Vec::new)
-                .push(pid_counter);
-            code_idx += 1;
+        let mut partition_pids_map: HashMap<i64, Vec<i64>> = HashMap::new();
+        let mut pid_counter = old_num_documents;
+        let mut code_idx = 0;
+        for &doc_len in &new_doclens_accumulated {
+            for _ in 0..doc_len {
+                let code = new_codes_vec[code_idx];
+                partition_pids_map
+                    .entry(code)
+                    .or_insert_with(Vec::new)
+                    .push(pid_counter);
+                code_idx += 1;
+            }
+            pid_counter += 1;
         }
-        pid_counter += 1;
-    }
 
-    let mut new_partition_data: HashMap<usize, Tensor> = HashMap::new();
-    for (code, mut pids) in partition_pids_map.into_iter() {
-        if code >= 0 && code < est_num_embeddings {
-            pids.sort_unstable();
-            pids.dedup();
-            let unique_pids = Tensor::from_slice(&pids).to_device(Device::Cpu);
-            new_partition_data.insert(code as usize, unique_pids);
+        let mut new_partition_data: HashMap<usize, Tensor> = HashMap::new();
+        for (code, mut pids) in partition_pids_map.into_iter() {
+            if code >= 0 && code < est_num_embeddings {
+                pids.sort_unstable();
+                pids.dedup();
+                let unique_pids = Tensor::from_slice(&pids).to_device(Device::Cpu);
+                new_partition_data.insert(code as usize, unique_pids);
+            }
         }
-    }
 
-    // Merge with old IVF
-    let old_ivf_flat = &index.ivf_index_strided.underlying_data;
-    let old_ivf_lengths = &index.ivf_index_strided.element_lengths;
-    let old_ivf_lengths_cpu = old_ivf_lengths.to_device(Device::Cpu);
-    let old_lengths_vec: Vec<i64> = Vec::<i64>::try_from(&old_ivf_lengths_cpu)?;
-    let num_partitions = est_num_embeddings as usize;
+        // Merge with old IVF
+        let ivf_strided = index.ivf_index_strided.as_ref().ok_or_else(|| {
+            anyhow!(
+                "Index metadata indicates compress_only=false but IVF data is missing. \
+                 The index may be corrupt."
+            )
+        })?;
+        let old_ivf_flat = &ivf_strided.underlying_data;
+        let old_ivf_lengths = &ivf_strided.element_lengths;
+        let old_ivf_lengths_cpu = old_ivf_lengths.to_device(Device::Cpu);
+        let old_lengths_vec: Vec<i64> = Vec::<i64>::try_from(&old_ivf_lengths_cpu)?;
+        let num_partitions = est_num_embeddings as usize;
 
-    if new_partition_data.is_empty() {
-        return Ok(());
-    }
+        if new_partition_data.is_empty() {
+            return Ok(());
+        }
 
-    let mut old_ivf_offsets = Vec::with_capacity(old_lengths_vec.len());
-    let mut curr = 0;
-    for &l in &old_lengths_vec {
-        old_ivf_offsets.push(curr);
-        curr += l;
-    }
+        let mut old_ivf_offsets = Vec::with_capacity(old_lengths_vec.len());
+        let mut curr = 0;
+        for &l in &old_lengths_vec {
+            old_ivf_offsets.push(curr);
+            curr += l;
+        }
 
-    let mut final_ivf_parts: Vec<Tensor> = Vec::new();
-    let mut final_lengths_vec: Vec<i64> = Vec::with_capacity(num_partitions);
+        let mut final_ivf_parts: Vec<Tensor> = Vec::new();
+        let mut final_lengths_vec: Vec<i64> = Vec::with_capacity(num_partitions);
 
-    let mut i = 0;
-    while i < num_partitions {
-        if let Some(new_pids) = new_partition_data.get(&i) {
-            let old_len = if i < old_lengths_vec.len() {
-                old_lengths_vec[i]
-            } else {
-                0
-            };
-            let new_len = new_pids.size()[0];
-            if old_len > 0 {
-                let start = old_ivf_offsets[i];
-                final_ivf_parts.push(
-                    old_ivf_flat
-                        .narrow(0, start, old_len)
-                        .to_device(Device::Cpu),
-                );
-            }
-            final_ivf_parts.push(new_pids.shallow_clone());
-            final_lengths_vec.push(old_len + new_len);
-            i += 1;
-        } else {
-            let range_start = i;
-            while i < num_partitions && !new_partition_data.contains_key(&i) {
-                i += 1;
-            }
-            let range_end = i;
-
-            let flat_start = if range_start < old_ivf_offsets.len() {
-                old_ivf_offsets[range_start]
-            } else {
-                0
-            };
-            let flat_end = if range_end < old_ivf_offsets.len() {
-                old_ivf_offsets[range_end]
-            } else if range_end > 0 && range_end - 1 < old_lengths_vec.len() {
-                old_ivf_offsets[range_end - 1] + old_lengths_vec[range_end - 1]
-            } else {
-                flat_start
-            };
-
-            let flat_length = flat_end - flat_start;
-            if flat_length > 0 {
-                final_ivf_parts.push(
-                    old_ivf_flat
-                        .narrow(0, flat_start, flat_length)
-                        .to_device(Device::Cpu),
-                );
-            }
-
-            for j in range_start..range_end {
-                let old_len = if j < old_lengths_vec.len() {
-                    old_lengths_vec[j]
+        let mut i = 0;
+        while i < num_partitions {
+            if let Some(new_pids) = new_partition_data.get(&i) {
+                let old_len = if i < old_lengths_vec.len() {
+                    old_lengths_vec[i]
                 } else {
                     0
                 };
-                final_lengths_vec.push(old_len);
+                let new_len = new_pids.size()[0];
+                if old_len > 0 {
+                    let start = old_ivf_offsets[i];
+                    final_ivf_parts.push(
+                        old_ivf_flat
+                            .narrow(0, start, old_len)
+                            .to_device(Device::Cpu),
+                    );
+                }
+                final_ivf_parts.push(new_pids.shallow_clone());
+                final_lengths_vec.push(old_len + new_len);
+                i += 1;
+            } else {
+                let range_start = i;
+                while i < num_partitions && !new_partition_data.contains_key(&i) {
+                    i += 1;
+                }
+                let range_end = i;
+
+                let flat_start = if range_start < old_ivf_offsets.len() {
+                    old_ivf_offsets[range_start]
+                } else {
+                    0
+                };
+                let flat_end = if range_end < old_ivf_offsets.len() {
+                    old_ivf_offsets[range_end]
+                } else if range_end > 0 && range_end - 1 < old_lengths_vec.len() {
+                    old_ivf_offsets[range_end - 1] + old_lengths_vec[range_end - 1]
+                } else {
+                    flat_start
+                };
+
+                let flat_length = flat_end - flat_start;
+                if flat_length > 0 {
+                    final_ivf_parts.push(
+                        old_ivf_flat
+                            .narrow(0, flat_start, flat_length)
+                            .to_device(Device::Cpu),
+                    );
+                }
+
+                for j in range_start..range_end {
+                    let old_len = if j < old_lengths_vec.len() {
+                        old_lengths_vec[j]
+                    } else {
+                        0
+                    };
+                    final_lengths_vec.push(old_len);
+                }
             }
         }
+
+        let final_ivf_tensor = Tensor::cat(&final_ivf_parts, 0);
+        let final_lengths_tensor = Tensor::from_slice(&final_lengths_vec)
+            .to_device(Device::Cpu)
+            .to_kind(Kind::Int);
+
+        // Write updated global files
+        final_ivf_tensor
+            .to_kind(Kind::Int64)
+            .write_npy(&idx_path_obj.join("ivf.npy"))?;
+        final_lengths_tensor.write_npy(&idx_path_obj.join("ivf_lengths.npy"))?;
     }
-
-    let final_ivf_tensor = Tensor::cat(&final_ivf_parts, 0);
-    let final_lengths_tensor = Tensor::from_slice(&final_lengths_vec)
-        .to_device(Device::Cpu)
-        .to_kind(Kind::Int);
-
-    // Write updated global files
-    final_ivf_tensor
-        .to_kind(Kind::Int64)
-        .write_npy(&idx_path_obj.join("ivf.npy"))?;
-    final_lengths_tensor.write_npy(&idx_path_obj.join("ivf_lengths.npy"))?;
+    drop(new_codes_accumulated);
 
     // Update global metadata
     let new_tokens_count: i64 = new_doclens_accumulated.iter().sum();
@@ -452,6 +464,7 @@ pub fn update_index(
         "num_embeddings": num_embeddings,
         "num_documents": total_num_documents,
         "avg_doclen": final_avg_doclen,
+        "compress_only": compress_only,
     });
     let final_meta_file = fs::File::create(&main_meta_path)?;
     serde_json::to_writer_pretty(BufWriter::new(final_meta_file), &final_meta_json)?;

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -123,6 +123,8 @@ fn initialize_torch(_py: Python<'_>, torch_path: String) -> PyResult<()> {
 ///         pre-computed by K-means on the Python side.
 ///     batch_size (int): Batch size for processing embeddings during creation.
 ///     seed (int | None): Optional seed for reproducible index creation.
+///     compress_only (bool): If True, skip IVF construction (index cannot be
+///         searched, but ``get_embeddings()`` still works).
 ///
 /// Raises:
 ///     RuntimeError: If index creation fails or `libtorch` fails to load.
@@ -138,6 +140,7 @@ fn create(
     centroids: PyTensor,
     batch_size: i64,
     seed: Option<u64>,
+    compress_only: bool,
 ) -> PyResult<()> {
     call_torch(torch_path)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to load Torch library: {}", e)))?;
@@ -154,6 +157,7 @@ fn create(
         centroids,
         batch_size,
         seed,
+        compress_only,
     )
     .map_err(|e| PyRuntimeError::new_err(format!("Failed to create index: {}", e)));
 

--- a/rust/search/load.rs
+++ b/rust/search/load.rs
@@ -49,7 +49,7 @@ pub struct Metadata {
 /// (IVF lists, compressed codes, and residuals).
 pub struct LoadedIndex {
     pub codec: ResidualCodec,
-    pub ivf_index_strided: StridedTensor,
+    pub ivf_index_strided: Option<StridedTensor>,
     pub doc_codes_strided: StridedTensor,
     pub doc_residuals_strided: StridedTensor,
     pub nbits: i64,
@@ -112,8 +112,8 @@ fn ensure_tensor(t: PyTensor, device: Device, kind: Kind) -> Tensor {
 /// * `avg_residual` - The average residual vector (float16).
 /// * `bucket_cutoffs` - Quantization bucket boundaries (float16).
 /// * `bucket_weights` - Quantization bucket values (float16).
-/// * `ivf` - The Inverted File index structure (int64).
-/// * `ivf_lengths` - Lengths of the IVF lists (int32).
+/// * `ivf` - The Inverted File index structure (int64). None for compress-only indices.
+/// * `ivf_lengths` - Lengths of the IVF lists (int32). None for compress-only indices.
 /// * `doc_codes` - The compressed document codes (int64).
 /// * `doc_residuals` - The compressed document residuals (uint8).
 /// * `doc_lengths` - The true lengths of documents (int64).
@@ -128,8 +128,8 @@ pub fn construct_index(
     avg_residual: PyTensor,
     bucket_cutoffs: PyTensor,
     bucket_weights: PyTensor,
-    ivf: PyTensor,
-    ivf_lengths: PyTensor,
+    ivf: Option<PyTensor>,
+    ivf_lengths: Option<PyTensor>,
     doc_codes: PyTensor,
     doc_residuals: PyTensor,
     doc_lengths: PyTensor,
@@ -152,12 +152,15 @@ pub fn construct_index(
     )
     .map_err(anyhow_to_pyerr)?;
 
-    // Build IVF index
-    let ivf_index_strided = StridedTensor::new(
-        ensure_tensor(ivf, main_device, Kind::Int64),
-        ensure_tensor(ivf_lengths, main_device, Kind::Int),
-        main_device,
-    );
+    // Build IVF index (None for compress-only indices)
+    let ivf_index_strided = match (ivf, ivf_lengths) {
+        (Some(ivf_t), Some(ivf_len_t)) => Some(StridedTensor::new(
+            ensure_tensor(ivf_t, main_device, Kind::Int64),
+            ensure_tensor(ivf_len_t, main_device, Kind::Int),
+            main_device,
+        )),
+        _ => None,
+    };
 
     // Load document data (large tensors, may stay on CPU in low memory mode)
     let doc_lens_t = ensure_tensor(doc_lengths, storage_device, Kind::Int64);

--- a/rust/search/search.rs
+++ b/rust/search/search.rs
@@ -224,6 +224,13 @@ pub fn search_many(
     show_progress: bool,
     subset: Option<Vec<Vec<i64>>>,
 ) -> Result<Vec<QueryResult>> {
+    let ivf_index = index.ivf_index_strided.as_ref().ok_or_else(|| {
+        anyhow!(
+            "This index was built with compress_only=True and does not support search. \
+             Rebuild with compress_only=False to enable search."
+        )
+    })?;
+
     let [num_queries, _, query_dim] = queries.size()[..] else {
         bail!(
             "Expected a 3D tensor for queries, but got shape {:?}",
@@ -244,7 +251,7 @@ pub fn search_many(
 
         let (passage_ids, scores, _) = search(
             &query_embedding,
-            &index.ivf_index_strided,
+            ivf_index,
             &index.codec,
             query_dim,
             &index.doc_codes_strided,
@@ -292,6 +299,13 @@ pub fn search_many_with_token_scores(
     show_progress: bool,
     subset: Option<Vec<Vec<i64>>>,
 ) -> Result<Vec<QueryResultWithTokenScores>> {
+    let ivf_index = index.ivf_index_strided.as_ref().ok_or_else(|| {
+        anyhow!(
+            "This index was built with compress_only=True and does not support search. \
+             Rebuild with compress_only=False to enable search."
+        )
+    })?;
+
     let [num_queries, _, query_dim] = queries.size()[..] else {
         bail!(
             "Expected a 3D tensor for queries, but got shape {:?}",
@@ -311,7 +325,7 @@ pub fn search_many_with_token_scores(
 
         let (passage_ids, scores, token_matrices) = search(
             &query_embedding,
-            &index.ivf_index_strided,
+            ivf_index,
             &index.codec,
             query_dim,
             &index.doc_codes_strided,

--- a/tests/test.py
+++ b/tests/test.py
@@ -707,6 +707,112 @@ class TestGetEmbeddings:
         )
 
 
+class TestCompressOnly:
+    """Tests for compress_only mode (no IVF construction)."""
+
+    def test_compress_only_get_embeddings(self, test_index_path):
+        """Test that get_embeddings works on a compress_only index."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        documents_embeddings = [torch.randn(100, 128, device="cpu") for _ in range(20)]
+        index.create(
+            documents_embeddings=documents_embeddings,
+            kmeans_niters=4,
+            compress_only=True,
+        )
+
+        # get_embeddings should work without IVF
+        reconstructed = index.get_embeddings(subset=[0, 5, 10])
+
+        assert len(reconstructed) == 3, (
+            f"Expected 3 reconstructed embeddings, got {len(reconstructed)}"
+        )
+        for emb in reconstructed:
+            assert emb.dim() == 2
+            assert emb.shape[1] == 128
+
+    def test_compress_only_no_ivf_files(self, test_index_path):
+        """Test that compress_only skips writing ivf.npy and ivf_lengths.npy."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        documents_embeddings = [torch.randn(100, 128, device="cpu") for _ in range(20)]
+        index.create(
+            documents_embeddings=documents_embeddings,
+            kmeans_niters=4,
+            compress_only=True,
+        )
+
+        assert not os.path.exists(os.path.join(test_index_path, "ivf.npy"))
+        assert not os.path.exists(os.path.join(test_index_path, "ivf_lengths.npy"))
+
+    def test_compress_only_search_raises(self, test_index_path):
+        """Test that search raises an error on a compress_only index."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        documents_embeddings = [torch.randn(100, 128, device="cpu") for _ in range(20)]
+        index.create(
+            documents_embeddings=documents_embeddings,
+            kmeans_niters=4,
+            compress_only=True,
+        )
+
+        queries_embeddings = torch.randn(2, 30, 128, device="cpu")
+        with pytest.raises((RuntimeError, ValueError), match="compress_only"):
+            index.search(queries_embeddings=queries_embeddings, top_k=5)
+
+    def test_compress_only_metadata_flag(self, test_index_path):
+        """Test that metadata.json contains compress_only field."""
+        import json
+
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        documents_embeddings = [torch.randn(100, 128, device="cpu") for _ in range(20)]
+        index.create(
+            documents_embeddings=documents_embeddings,
+            kmeans_niters=4,
+            compress_only=True,
+        )
+
+        with open(os.path.join(test_index_path, "metadata.json")) as f:
+            metadata = json.load(f)
+
+        assert metadata["compress_only"] is True
+
+    def test_compress_only_update_and_get_embeddings(self, test_index_path):
+        """Test that update works on a compress_only index and get_embeddings still works."""
+        import json
+
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        documents_embeddings = [torch.randn(100, 128, device="cpu") for _ in range(20)]
+        index.create(
+            documents_embeddings=documents_embeddings,
+            kmeans_niters=4,
+            compress_only=True,
+        )
+
+        # Update with new documents
+        new_embeddings = [torch.randn(80, 128, device="cpu") for _ in range(5)]
+        index.update(documents_embeddings=new_embeddings)
+
+        # IVF files should still not exist
+        assert not os.path.exists(os.path.join(test_index_path, "ivf.npy"))
+        assert not os.path.exists(os.path.join(test_index_path, "ivf_lengths.npy"))
+
+        # compress_only flag should be preserved in metadata
+        with open(os.path.join(test_index_path, "metadata.json")) as f:
+            metadata = json.load(f)
+        assert metadata["compress_only"] is True
+        assert metadata["num_documents"] == 25
+
+        # get_embeddings should work for both old and new documents
+        reconstructed = index.get_embeddings(subset=[0, 10, 22])
+        assert len(reconstructed) == 3
+        for emb in reconstructed:
+            assert emb.dim() == 2
+            assert emb.shape[1] == 128
+
+
 class TestQueryFormats:
     """Tests for different query embedding formats."""
 


### PR DESCRIPTION
When only compressed token storage and decompression via get_embeddings() is needed, the IVF construction is pure overhead. This adds a compress_only parameter to create() that skips IVF building (ivf.npy, ivf_lengths.npy), saving significant memory and compute for large collections. The flag is persisted in metadata.json and respected by update(). Search raises a clear error on compress-only indices.

Rationale: [SPLATE](https://arxiv.org/abs/2404.13950v1) can be used to retrieve document candidates rather than the IVF index, but we still need to rely on the compressed representations to store the document token vectors.