### PR TITLE
Add support for PyTorch 2.10.0 and 2.11.0

### DIFF
--- a/.github/workflows/publish-2100.yaml
+++ b/.github/workflows/publish-2100.yaml
@@ -1,0 +1,100 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - 2100
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Free Disk Space (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Prepare pyproject.toml
+        shell: bash
+        run: |
+          echo "Deleting existing pyproject.toml (if any)..."
+          rm -f pyproject.toml
+          echo "Using ci-2100.toml as pyproject.toml..."
+          cp ci-2100.toml pyproject.toml
+          echo "File preparation complete."
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Prepare Python Version for CIBW_BUILD
+        id: prepare_python_version
+        shell: bash
+        run: |
+          PYTHON_VERSION_NO_DOT=$(echo "${{ matrix.python-version }}" | tr -d '.')
+          echo "PYTHON_VERSION_NO_DOT=$PYTHON_VERSION_NO_DOT" >> $GITHUB_OUTPUT
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.3.1
+        env:
+          CIBW_ENABLE: cpython-prerelease
+          CIBW_BUILD: "cp${{ steps.prepare_python_version.outputs.PYTHON_VERSION_NO_DOT }}-*"
+          CIBW_SKIP: "*-manylinux_i686 *-musllinux_* *-win32 cp314t-*"
+          CIBW_BUILD_VERBOSITY: 1
+          LIBTORCH_BYPASS_VERSION_CHECK: 1
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_ARM64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT: 'PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu/torch_stable.html" PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
+          CIBW_PIP_ARGS: "--no-cache-dir --no-build-isolation"
+          CIBW_BEFORE_BUILD: "pip install torch==2.10.0 numpy maturin delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+            LD_LIBRARY_PATH=$(python -c 'import torch, os; print(os.path.join(os.path.dirname(torch.__file__), "lib"))'):$LD_LIBRARY_PATH auditwheel repair -w {dest_dir} {wheel} --exclude libtorch.so --exclude libtorch_cpu.so --exclude libtorch_python.so
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            DYLD_LIBRARY_PATH=$(python -c 'import torch, os; print(os.path.join(os.path.dirname(torch.__file__), "lib"))') delocate-wheel -w {dest_dir} -v {wheel} --exclude libtorch.dylib --exclude libtorch_cpu.dylib --exclude libtorch_python.dylib
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+            FOR /F "usebackq tokens=*" %i IN (`python -c "import torch, os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))"`) DO (set "PATH=%i;%PATH%" && delvewheel repair -w {dest_dir} {wheel} --no-dll torch.dll --no-dll torch_cpu.dll --no-dll torch_python.dll)
+
+      - name: Upload wheels to artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: ./wheelhouse/*.whl
+
+  publish:
+    name: Publish 2100 to PyPI
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*-py*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/publish-2110.yaml
+++ b/.github/workflows/publish-2110.yaml
@@ -1,0 +1,100 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} - 2110
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Free Disk Space (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Prepare pyproject.toml
+        shell: bash
+        run: |
+          echo "Deleting existing pyproject.toml (if any)..."
+          rm -f pyproject.toml
+          echo "Using ci-2110.toml as pyproject.toml..."
+          cp ci-2110.toml pyproject.toml
+          echo "File preparation complete."
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Prepare Python Version for CIBW_BUILD
+        id: prepare_python_version
+        shell: bash
+        run: |
+          PYTHON_VERSION_NO_DOT=$(echo "${{ matrix.python-version }}" | tr -d '.')
+          echo "PYTHON_VERSION_NO_DOT=$PYTHON_VERSION_NO_DOT" >> $GITHUB_OUTPUT
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.3.1
+        env:
+          CIBW_ENABLE: cpython-prerelease
+          CIBW_BUILD: "cp${{ steps.prepare_python_version.outputs.PYTHON_VERSION_NO_DOT }}-*"
+          CIBW_SKIP: "*-manylinux_i686 *-musllinux_* *-win32 cp314t-*"
+          CIBW_BUILD_VERBOSITY: 1
+          LIBTORCH_BYPASS_VERSION_CHECK: 1
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_ARM64_IMAGE: manylinux_2_28
+          CIBW_ENVIRONMENT: 'PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu/torch_stable.html" PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1'
+          CIBW_PIP_ARGS: "--no-cache-dir --no-build-isolation"
+          CIBW_BEFORE_BUILD: "pip install torch==2.11.0 numpy maturin delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+            LD_LIBRARY_PATH=$(python -c 'import torch, os; print(os.path.join(os.path.dirname(torch.__file__), "lib"))'):$LD_LIBRARY_PATH auditwheel repair -w {dest_dir} {wheel} --exclude libtorch.so --exclude libtorch_cpu.so --exclude libtorch_python.so
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            DYLD_LIBRARY_PATH=$(python -c 'import torch, os; print(os.path.join(os.path.dirname(torch.__file__), "lib"))') delocate-wheel -w {dest_dir} -v {wheel} --exclude libtorch.dylib --exclude libtorch_cpu.dylib --exclude libtorch_python.dylib
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+            FOR /F "usebackq tokens=*" %i IN (`python -c "import torch, os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))"`) DO (set "PATH=%i;%PATH%" && delvewheel repair -w {dest_dir} {wheel} --no-dll torch.dll --no-dll torch_cpu.dll --no-dll torch_python.dll)
+
+      - name: Upload wheels to artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: ./wheelhouse/*.whl
+
+  publish:
+    name: Publish 2110 to PyPI
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*-py*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true

--- a/ci-2100.toml
+++ b/ci-2100.toml
@@ -1,0 +1,152 @@
+[build-system]
+requires = [
+  "maturin >= 1.8.6",
+  "numpy >= 1.26.4",
+  "setuptools >= 78.1.1",
+  "torch == 2.10.0",
+]
+build-backend = "maturin"
+
+[project]
+name = "fast_plaid"
+version = "1.4.6.2100"
+description = "Fast Plaid."
+authors = [
+  { name = "Raphael Sourty, LightOn", email = "raphael.sourty@lighton.ai" },
+]
+keywords = []
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Rust",
+  "Operating System :: OS Independent",
+]
+requires-python = ">=3.10"
+dependencies = [
+  "fastkmeans == 0.5.0",
+  "joblib>=1.5.1",
+  "torch == 2.10.0",
+  "maturin >= 1.8.6",
+  "numpy >= 1.26.4",
+  "setuptools >= 78.1.1",
+  "filelock>=3.20.0",
+  "usearch>=2.21.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "maturin >= 1.8.6",
+  "pytest-cov >= 5.0.0",
+  "pytest >= 7.4.4",
+  "ruff >= 0.1.15",
+  "pre-commit >= 3.0.0",
+  "pylate >= 1.2.1",
+  "beir>=2.1.0",
+  "ranx>=0.3.20",
+]
+
+[project.urls]
+Homepage = "https://github.com/lightonai/fast-plaid"
+Documentation = "https://github.com/lightonai/fast-plaid"
+Repository = "https://github.com/lightonai/fast-plaid"
+
+[tool.include]
+include = ["Cargo.toml", "pyproject.toml", "README.md", "rust/*"]
+
+[tool.maturin]
+bindings = "pyo3"
+features = ["pyo3/extension-module"]
+python-source = "python"
+module-name = "fast_plaid.fast_plaid_rust"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+  "ignore::DeprecationWarning",
+  "ignore::RuntimeWarning",
+  "ignore::UserWarning",
+]
+addopts = [
+  "--doctest-modules",
+  "--verbose",
+  "-ra",
+  "--cov-config=.coveragerc",
+  "-m not web and not slow",
+]
+doctest_optionflags = ["NORMALIZE_WHITESPACE", "NUMBER"]
+norecursedirs = ["build", "docs", "node_modules"]
+markers = [
+  "web: tests that require using the Internet",
+  "slow: tests that take a long time to run",
+]
+
+[tool.ruff]
+line-length = 88
+indent-width = 4
+target-version = "py310"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = false
+docstring-code-line-length = "dynamic"
+
+[tool.ruff.lint]
+ignore = [
+  "ANN001",
+  "TID252",
+  "FBT002",
+  "ANN201",
+  "G004",
+  "BLE001",
+  "S112",
+  "PTH123",
+  "S101",
+  "ANN204",
+  "PLR2004",
+  "D104",
+  "D100",
+  "PTH118",
+  "PTH110",
+  "PTH103",
+  "S311",
+  "T201",
+  "FBT001",
+  "D107",
+  "PTH107",
+  "PTH109",
+  "S603",
+  "S607",
+  "PGH004",
+  "PLC0206",
+  "PLW1508",
+  "INP001",
+  "FIX002",
+  "TD003",
+  "PGH003",
+  "ANN401",
+  "PERF401",
+  "D203",
+  "D213",
+  "COM812",
+  "N812",
+  "PTH207",
+  "PTH120",
+  "SIM105",
+  "PERF203",
+  "TRY203",
+  "TRY201",
+  "PTH112",
+  "B905",
+  "UP037",
+  "PLC0415",
+]
+select = ["ALL"]
+fixable = ["ALL"]
+unfixable = []
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/ci-2110.toml
+++ b/ci-2110.toml
@@ -1,0 +1,152 @@
+[build-system]
+requires = [
+  "maturin >= 1.8.6",
+  "numpy >= 1.26.4",
+  "setuptools >= 78.1.1",
+  "torch == 2.11.0",
+]
+build-backend = "maturin"
+
+[project]
+name = "fast_plaid"
+version = "1.4.6.2110"
+description = "Fast Plaid."
+authors = [
+  { name = "Raphael Sourty, LightOn", email = "raphael.sourty@lighton.ai" },
+]
+keywords = []
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Rust",
+  "Operating System :: OS Independent",
+]
+requires-python = ">=3.10"
+dependencies = [
+  "fastkmeans == 0.5.0",
+  "joblib>=1.5.1",
+  "torch == 2.11.0",
+  "maturin >= 1.8.6",
+  "numpy >= 1.26.4",
+  "setuptools >= 78.1.1",
+  "filelock>=3.20.0",
+  "usearch>=2.21.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "maturin >= 1.8.6",
+  "pytest-cov >= 5.0.0",
+  "pytest >= 7.4.4",
+  "ruff >= 0.1.15",
+  "pre-commit >= 3.0.0",
+  "pylate >= 1.2.1",
+  "beir>=2.1.0",
+  "ranx>=0.3.20",
+]
+
+[project.urls]
+Homepage = "https://github.com/lightonai/fast-plaid"
+Documentation = "https://github.com/lightonai/fast-plaid"
+Repository = "https://github.com/lightonai/fast-plaid"
+
+[tool.include]
+include = ["Cargo.toml", "pyproject.toml", "README.md", "rust/*"]
+
+[tool.maturin]
+bindings = "pyo3"
+features = ["pyo3/extension-module"]
+python-source = "python"
+module-name = "fast_plaid.fast_plaid_rust"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+  "ignore::DeprecationWarning",
+  "ignore::RuntimeWarning",
+  "ignore::UserWarning",
+]
+addopts = [
+  "--doctest-modules",
+  "--verbose",
+  "-ra",
+  "--cov-config=.coveragerc",
+  "-m not web and not slow",
+]
+doctest_optionflags = ["NORMALIZE_WHITESPACE", "NUMBER"]
+norecursedirs = ["build", "docs", "node_modules"]
+markers = [
+  "web: tests that require using the Internet",
+  "slow: tests that take a long time to run",
+]
+
+[tool.ruff]
+line-length = 88
+indent-width = 4
+target-version = "py310"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = false
+docstring-code-line-length = "dynamic"
+
+[tool.ruff.lint]
+ignore = [
+  "ANN001",
+  "TID252",
+  "FBT002",
+  "ANN201",
+  "G004",
+  "BLE001",
+  "S112",
+  "PTH123",
+  "S101",
+  "ANN204",
+  "PLR2004",
+  "D104",
+  "D100",
+  "PTH118",
+  "PTH110",
+  "PTH103",
+  "S311",
+  "T201",
+  "FBT001",
+  "D107",
+  "PTH107",
+  "PTH109",
+  "S603",
+  "S607",
+  "PGH004",
+  "PLC0206",
+  "PLW1508",
+  "INP001",
+  "FIX002",
+  "TD003",
+  "PGH003",
+  "ANN401",
+  "PERF401",
+  "D203",
+  "D213",
+  "COM812",
+  "N812",
+  "PTH207",
+  "PTH120",
+  "SIM105",
+  "PERF203",
+  "TRY203",
+  "TRY201",
+  "PTH112",
+  "B905",
+  "UP037",
+  "PLC0415",
+]
+select = ["ALL"]
+fixable = ["ALL"]
+unfixable = []
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"


### PR DESCRIPTION
## Summary
- Add CI config (`ci-2100.toml`, `ci-2110.toml`) and publish workflows (`publish-2100.yaml`, `publish-2110.yaml`) for PyTorch 2.10.0 and 2.11.0
- Follows the existing per-version pattern, based on the latest `ci-290.toml` / `publish-290.yaml` templates
- Includes Python 3.14 support and `cpython-prerelease` settings carried over from the 2.9.0 workflow

## Test plan
- [ ] Trigger `publish-2100` workflow manually and verify wheels build successfully
- [ ] Trigger `publish-2110` workflow manually and verify wheels build successfully
- [ ] Verify published wheels install correctly with `pip install fast_plaid==1.4.6.2100` and `fast_plaid==1.4.6.2110`

🤖 Generated with [Claude Code](https://claude.com/claude-code)