### PR TITLE
remove maturin + setuptools from package deps

### DIFF
--- a/ci-2100.toml
+++ b/ci-2100.toml
@@ -30,9 +30,7 @@ dependencies = [
   "fastkmeans == 0.5.0",
   "joblib>=1.5.1",
   "torch == 2.10.0",
-  "maturin >= 1.8.6",
   "numpy >= 1.26.4",
-  "setuptools >= 78.1.1",
   "filelock>=3.20.0",
   "usearch>=2.21.0",
 ]

--- a/ci-2110.toml
+++ b/ci-2110.toml
@@ -30,9 +30,7 @@ dependencies = [
   "fastkmeans == 0.5.0",
   "joblib>=1.5.1",
   "torch == 2.11.0",
-  "maturin >= 1.8.6",
   "numpy >= 1.26.4",
-  "setuptools >= 78.1.1",
   "filelock>=3.20.0",
   "usearch>=2.21.0",
 ]

--- a/ci-270.toml
+++ b/ci-270.toml
@@ -30,9 +30,7 @@ dependencies = [
   "fastkmeans == 0.5.0",
   "joblib>=1.5.1",
   "torch == 2.7.0",
-  "maturin >= 1.8.6",
   "numpy >= 1.26.4",
-  "setuptools >= 78.1.1",
   "filelock>=3.20.0",
   "usearch>=2.21.0",
 ]

--- a/ci-271.toml
+++ b/ci-271.toml
@@ -30,9 +30,7 @@ dependencies = [
   "fastkmeans == 0.5.0",
   "joblib>=1.5.1",
   "torch == 2.7.1",
-  "maturin >= 1.8.6",
   "numpy >= 1.26.4",
-  "setuptools >= 78.1.1",
   "filelock>=3.20.0",
   "usearch>=2.21.0",
 ]

--- a/ci-280.toml
+++ b/ci-280.toml
@@ -30,9 +30,7 @@ dependencies = [
   "fastkmeans == 0.5.0",
   "joblib>=1.5.1",
   "torch == 2.8.0",
-  "maturin >= 1.8.6",
   "numpy >= 1.26.4",
-  "setuptools >= 78.1.1",
   "filelock>=3.20.0",
   "usearch>=2.21.0",
 ]

--- a/ci-290.toml
+++ b/ci-290.toml
@@ -30,9 +30,7 @@ dependencies = [
   "fastkmeans == 0.5.0",
   "joblib>=1.5.1",
   "torch == 2.9.0",
-  "maturin >= 1.8.6",
   "numpy >= 1.26.4",
-  "setuptools >= 78.1.1",
   "filelock>=3.20.0",
   "usearch>=2.21.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,7 @@ dependencies = [
   "fastkmeans == 0.5.0",
   "joblib>=1.5.1",
   "torch >= 2.6.0",
-  "maturin >= 1.8.6",
   "numpy >= 1.26.4",
-  "setuptools >= 78.1.1",
   "filelock>=3.20.0",
   "usearch>=2.21.0",
 ]


### PR DESCRIPTION
Hey! The `pyproject.toml` files currently list `maturin` and `setuptools` as dependencies of the built package artifact. That is not ideal, because installing `fast-plaid` now pulls in `maturin` and `setuptools` for consumers too. I ran into this while building the package on conda-forge [here](https://github.com/conda-forge/staged-recipes/pull/32983), and this is my attempt to fix the root cause.
