### PR TITLE
Add freeze() to drop per-shard codes/residuals for read-only indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,6 @@ This approach balances efficiency with accuracy: small updates are fast, while l
 
 &nbsp;
 
-## 🧊 Freezing a Read-Only Index
-
-Once you no longer plan to mutate an index, call `fast_plaid.freeze()` to drop the per-shard `{i}.codes.npy` / `{i}.residuals.npy` files and keep only the merged storage, roughly halving on-disk size with no impact on search. The change is reversible via `fast_plaid.unfreeze()`, which rebuilds the shards byte-for-byte from the merged file.
-
-&nbsp;
-
 ## 🔎 Filtering
 
 You can restrict your search to a specific subset of documents by using the `subset` parameter in the `.search()` method. This is useful for implementing metadata filtering or searching within a pre-defined collection.
@@ -686,3 +680,9 @@ for match in scores:
 
 You can also rely on the existing subset parameter of the .search() method to filter candidates based
 on the order of insertion or rely on an external filtering system as providing the metadata parameter is optional.
+
+&nbsp;
+
+## 🧊 Freezing a Read-Only Index
+
+Once you no longer plan to mutate an index, call `fast_plaid.freeze()` to drop the per-shard `{i}.codes.npy` / `{i}.residuals.npy` files and keep only the merged storage, roughly halving on-disk size with no impact on search. The change is reversible via `fast_plaid.unfreeze()`, which rebuilds the shards byte-for-byte from the merged file.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ This approach balances efficiency with accuracy: small updates are fast, while l
 
 &nbsp;
 
+## 🧊 Freezing a Read-Only Index
+
+Once you no longer plan to mutate an index, call `fast_plaid.freeze()` to drop the per-shard `{i}.codes.npy` / `{i}.residuals.npy` files and keep only the merged storage, roughly halving on-disk size with no impact on search. The change is reversible via `fast_plaid.unfreeze()`, which rebuilds the shards byte-for-byte from the merged file.
+
+&nbsp;
+
 ## 🔎 Filtering
 
 You can restrict your search to a specific subset of documents by using the `subset` parameter in the `.search()` method. This is useful for implementing metadata filtering or searching within a pre-defined collection.

--- a/python/fast_plaid/search/fast_plaid.py
+++ b/python/fast_plaid/search/fast_plaid.py
@@ -708,7 +708,9 @@ class FastPlaid:
                             pass
 
             meta["frozen"] = True
-            with open(meta_path, "w") as f:
+            # newline="\n" prevents Windows text-mode translation; Rust's
+            # serde_json::to_writer_pretty always uses \n regardless of platform.
+            with open(meta_path, "w", newline="\n") as f:
                 json.dump(meta, f, indent=2)
 
             self._update_mtime()
@@ -828,7 +830,7 @@ class FastPlaid:
 
             # Drop the frozen marker entirely to restore byte-identical metadata.
             meta.pop("frozen", None)
-            with open(meta_path, "w") as f:
+            with open(meta_path, "w", newline="\n") as f:
                 json.dump(meta, f, indent=2)
 
             self._update_mtime()

--- a/python/fast_plaid/search/fast_plaid.py
+++ b/python/fast_plaid/search/fast_plaid.py
@@ -709,9 +709,131 @@ class FastPlaid:
 
             meta["frozen"] = True
             with open(meta_path, "w") as f:
-                json.dump(meta, f)
+                json.dump(meta, f, indent=2)
 
             self._update_mtime()
+
+        return self
+
+    @staticmethod
+    def _write_tch_compatible_npy(path: str, arr: np.ndarray) -> None:
+        """Write a .npy file byte-identical to ``tch::Tensor::write_npy``.
+
+        Differs from ``np.save`` in two places:
+
+        - Multi-dim shapes are formatted ``(R,C,)`` (Rust style: trailing
+          comma, no spaces), not ``(R, C)``.
+        - Byte order is always ``<`` even for 1-byte types (numpy uses ``|``).
+        - The header is padded so the prologue (10 + header) is a multiple
+          of 16, matching tch's alignment.
+        """
+        arr = np.ascontiguousarray(arr)
+        kind_size = arr.dtype.kind + str(arr.dtype.itemsize)
+        descr = f"<{kind_size}"
+
+        if arr.ndim == 1:
+            shape_str = f"({arr.shape[0]},)"
+        else:
+            shape_str = "(" + ",".join(str(s) for s in arr.shape) + ",)"
+
+        header_body = (
+            f"{{'descr': '{descr}', 'fortran_order': False, "
+            f"'shape': {shape_str}, }}"
+        )
+
+        prologue_fixed = 10  # magic(6) + version(2) + header_len_field(2)
+        body_with_newline = len(header_body) + 1
+        target = ((prologue_fixed + body_with_newline + 15) // 16) * 16
+        pad = target - prologue_fixed - body_with_newline
+
+        header = header_body + (" " * pad) + "\n"
+        header_bytes = header.encode("ascii")
+
+        with open(path, "wb") as f:
+            f.write(b"\x93NUMPY\x01\x00")
+            f.write(len(header_bytes).to_bytes(2, "little"))
+            f.write(header_bytes)
+            f.write(arr.tobytes())
+
+    def unfreeze(self) -> "FastPlaid":
+        """Rebuild per-shard codes/residuals from the merged file.
+
+        Inverse of ``freeze()``. Slices ``merged_codes.npy`` / ``merged_residuals.npy``
+        back into ``{i}.codes.npy`` / ``{i}.residuals.npy`` according to each
+        shard's ``doclens.{i}.json``, then clears the ``frozen`` flag.
+
+        Restores the ability to call ``update()`` / ``delete()``.
+        """
+        with self.lock:
+            meta_path = os.path.join(self.index, "metadata.json")
+            if not os.path.exists(meta_path):
+                error = f"No index found at {self.index} to unfreeze."
+                raise FileNotFoundError(error)
+
+            with open(meta_path) as f:
+                meta = json.load(f)
+
+            if not meta.get("frozen", False):
+                return self
+
+            num_chunks = meta.get("num_chunks", 0)
+
+            merged_codes_path = os.path.join(self.index, "merged_codes.npy")
+            merged_residuals_path = os.path.join(self.index, "merged_residuals.npy")
+            for merged_path in (merged_codes_path, merged_residuals_path):
+                if not os.path.exists(merged_path):
+                    error = (
+                        f"Cannot unfreeze: {merged_path} missing — index data is gone."
+                    )
+                    raise FileNotFoundError(error)
+
+            # Release any open mmaps on the merged files before we read them.
+            with self._index_swap_lock:
+                self.indices.clear()
+            gc.collect()
+
+            codes_mmap = np.load(merged_codes_path, mmap_mode="r")
+            residuals_mmap = np.load(merged_residuals_path, mmap_mode="r")
+
+            offset = 0
+            for i in range(num_chunks):
+                doclens_path = os.path.join(self.index, f"doclens.{i}.json")
+                if not os.path.exists(doclens_path):
+                    error = f"Cannot unfreeze: {doclens_path} missing."
+                    raise FileNotFoundError(error)
+                with open(doclens_path) as f:
+                    chunk_doclens = json.load(f)
+                chunk_rows = sum(chunk_doclens)
+
+                chunk_codes = np.ascontiguousarray(
+                    codes_mmap[offset : offset + chunk_rows]
+                )
+                chunk_residuals = np.ascontiguousarray(
+                    residuals_mmap[offset : offset + chunk_rows]
+                )
+
+                self._write_tch_compatible_npy(
+                    os.path.join(self.index, f"{i}.codes.npy"),
+                    chunk_codes,
+                )
+                self._write_tch_compatible_npy(
+                    os.path.join(self.index, f"{i}.residuals.npy"),
+                    chunk_residuals,
+                )
+
+                offset += chunk_rows
+
+            del codes_mmap, residuals_mmap
+            gc.collect()
+
+            # Drop the frozen marker entirely to restore byte-identical metadata.
+            meta.pop("frozen", None)
+            with open(meta_path, "w") as f:
+                json.dump(meta, f, indent=2)
+
+            self._update_mtime()
+            # Reload so the in-memory indices reflect the restored shard layout.
+            self._reload_under_lock(Path(meta_path).stat().st_mtime)
 
         return self
 

--- a/python/fast_plaid/search/fast_plaid.py
+++ b/python/fast_plaid/search/fast_plaid.py
@@ -637,6 +637,84 @@ class FastPlaid:
         return self
 
     @torch.inference_mode()
+    def _assert_not_frozen(self, operation: str) -> None:
+        """Refuse mutating operations on a frozen index.
+
+        A frozen index has had its per-shard ``{i}.codes.npy`` /
+        ``{i}.residuals.npy`` files deleted, so ``update`` and ``delete``
+        (which operate per shard) can't run without re-sharding first.
+        """
+        meta_path = os.path.join(self.index, "metadata.json")
+        if not os.path.exists(meta_path):
+            return
+        with open(meta_path) as f:
+            meta = json.load(f)
+        if meta.get("frozen", False):
+            error = (
+                f"Cannot {operation} a frozen index. "
+                f"Re-create the index from source embeddings if mutation is needed."
+            )
+            raise RuntimeError(error)
+
+    def freeze(self) -> "FastPlaid":
+        """Drop per-shard codes/residuals to halve on-disk storage.
+
+        After indexing, FastPlaid keeps both the per-shard files
+        (``{i}.codes.npy``, ``{i}.residuals.npy``) used by ``update``/``delete``
+        and a merged file (``merged_codes.npy``, ``merged_residuals.npy``) used
+        at search time. For a read-only index the shards are redundant.
+
+        ``freeze()`` ensures the merged file is up to date, then deletes every
+        per-shard ``codes``/``residuals`` file and writes ``"frozen": true``
+        into ``metadata.json``. Subsequent ``update``/``delete`` calls raise.
+        Search is unaffected and reloads become slightly faster (the chunk scan
+        is skipped).
+
+        This is irreversible without re-indexing from the source embeddings.
+        """
+        with self.lock:
+            meta_path = os.path.join(self.index, "metadata.json")
+            if not os.path.exists(meta_path):
+                error = f"No index found at {self.index} to freeze."
+                raise FileNotFoundError(error)
+
+            # Force a reload so the merged file reflects the current shards.
+            self._reload_under_lock(Path(meta_path).stat().st_mtime)
+
+            with open(meta_path) as f:
+                meta = json.load(f)
+
+            if meta.get("frozen", False):
+                return self
+
+            num_chunks = meta.get("num_chunks", 0)
+
+            for suffix in ("codes", "residuals"):
+                merged_path = os.path.join(self.index, f"merged_{suffix}.npy")
+                if not os.path.exists(merged_path):
+                    error = (
+                        f"Cannot freeze: {merged_path} does not exist. "
+                        f"Load the index at least once before freezing."
+                    )
+                    raise FileNotFoundError(error)
+
+            for i in range(num_chunks):
+                for suffix in ("codes", "residuals"):
+                    shard_path = os.path.join(self.index, f"{i}.{suffix}.npy")
+                    if os.path.exists(shard_path):
+                        try:
+                            os.remove(shard_path)
+                        except OSError:
+                            pass
+
+            meta["frozen"] = True
+            with open(meta_path, "w") as f:
+                json.dump(meta, f)
+
+            self._update_mtime()
+
+        return self
+
     def update(
         self,
         documents_embeddings: list[torch.Tensor] | torch.Tensor,
@@ -679,6 +757,7 @@ class FastPlaid:
         """
         # Exclusive Lock for Modification
         with self.lock:
+            self._assert_not_frozen("update")
             # Get current indices snapshot for the update operation
             with self._index_swap_lock:
                 current_indices = dict(self.indices)
@@ -1059,6 +1138,7 @@ class FastPlaid:
         """
         # Exclusive Lock for Modification
         with self.lock:
+            self._assert_not_frozen("delete from")
             primary_device = self.devices[0]
 
             fast_plaid_rust.delete(

--- a/python/fast_plaid/search/load.py
+++ b/python/fast_plaid/search/load.py
@@ -217,6 +217,28 @@ def _get_merged_mmap(  # noqa: PLR0912
     return torch.from_numpy(arr).to(device=device, dtype=dtype)
 
 
+def _mmap_frozen_tensor(
+    name_suffix: str,
+    dtype: torch.dtype,
+    device: str,
+    index_path: str,
+) -> torch.Tensor:
+    """Load a pre-existing merged_*.npy directly via mmap, with no chunk scan.
+
+    Used when the index is marked ``frozen``: the per-shard files have been
+    dropped, so the merged file is the sole source of truth.
+    """
+    merged_path = os.path.join(index_path, f"merged_{name_suffix}.npy")
+    if not os.path.exists(merged_path):
+        error = (
+            f"Frozen index is missing {merged_path}. "
+            f"The merged file is required when per-shard files have been dropped."
+        )
+        raise FileNotFoundError(error)
+    arr = np.load(merged_path, mmap_mode="c")
+    return torch.from_numpy(arr).to(device=device, dtype=dtype)
+
+
 def _load_index_tensors_cpu(index_path: str) -> dict[str, Any] | None:
     """Load index data into CPU tensors.
 
@@ -236,6 +258,7 @@ def _load_index_tensors_cpu(index_path: str) -> dict[str, Any] | None:
         metadata = json.load(f)
 
     num_chunks = metadata["num_chunks"]
+    frozen = metadata.get("frozen", False)
     device = "cpu"
 
     data = {
@@ -299,25 +322,39 @@ def _load_index_tensors_cpu(index_path: str) -> dict[str, Any] | None:
     last_len = all_doc_lens[-1] if all_doc_lens else 0
     padding_needed = max(0, max_len - last_len)
 
-    data["doc_codes"] = _get_merged_mmap(
-        name_suffix="codes",
-        dtype=torch.int64,
-        numpy_dtype=np.int64,
-        padding_needed=padding_needed,
-        device=device,
-        index_path=index_path,
-        num_chunks=num_chunks,
-    )
+    if frozen:
+        data["doc_codes"] = _mmap_frozen_tensor(
+            name_suffix="codes",
+            dtype=torch.int64,
+            device=device,
+            index_path=index_path,
+        )
+        data["doc_residuals"] = _mmap_frozen_tensor(
+            name_suffix="residuals",
+            dtype=torch.uint8,
+            device=device,
+            index_path=index_path,
+        )
+    else:
+        data["doc_codes"] = _get_merged_mmap(
+            name_suffix="codes",
+            dtype=torch.int64,
+            numpy_dtype=np.int64,
+            padding_needed=padding_needed,
+            device=device,
+            index_path=index_path,
+            num_chunks=num_chunks,
+        )
 
-    data["doc_residuals"] = _get_merged_mmap(
-        name_suffix="residuals",
-        dtype=torch.uint8,
-        numpy_dtype=np.uint8,
-        padding_needed=padding_needed,
-        device=device,
-        index_path=index_path,
-        num_chunks=num_chunks,
-    )
+        data["doc_residuals"] = _get_merged_mmap(
+            name_suffix="residuals",
+            dtype=torch.uint8,
+            numpy_dtype=np.uint8,
+            padding_needed=padding_needed,
+            device=device,
+            index_path=index_path,
+            num_chunks=num_chunks,
+        )
 
     return data
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1352,6 +1352,132 @@ class TestFilteringModule:
         assert all_metadata[2]["extra_field"] == "value", "extra_field has wrong value"
 
 
+class TestFreeze:
+    """Tests for the freeze() API that drops per-shard codes/residuals."""
+
+    def test_freeze_removes_shards_and_search_still_works(self, test_index_path):
+        """freeze() deletes per-shard files but search results stay identical."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        try:
+            documents_embeddings = [
+                torch.randn(100, 128, device="cpu") for _ in range(80)
+            ]
+            queries_embeddings = torch.randn(5, 30, 128, device="cpu")
+
+            index.create(documents_embeddings=documents_embeddings, kmeans_niters=4)
+            results_before = index.search(
+                queries_embeddings=queries_embeddings, top_k=10
+            )
+
+            # Shards must exist before freeze.
+            shard_files_before = [
+                f
+                for f in os.listdir(test_index_path)
+                if f.endswith(".codes.npy") and not f.startswith("merged_")
+            ]
+            assert len(shard_files_before) > 0, "expected per-shard codes files"
+
+            index.freeze()
+
+            # Shards gone, merged files retained.
+            shard_files_after = [
+                f
+                for f in os.listdir(test_index_path)
+                if f.endswith(".codes.npy") and not f.startswith("merged_")
+            ]
+            assert shard_files_after == [], (
+                f"expected all shard codes files deleted, got {shard_files_after}"
+            )
+            assert os.path.exists(os.path.join(test_index_path, "merged_codes.npy"))
+            assert os.path.exists(
+                os.path.join(test_index_path, "merged_residuals.npy")
+            )
+
+            results_after = index.search(
+                queries_embeddings=queries_embeddings, top_k=10
+            )
+            assert results_before == results_after, (
+                "freeze() must not change search results"
+            )
+        finally:
+            index.close()
+
+    def test_freeze_persists_across_reload(self, test_index_path):
+        """A frozen index reloads correctly from disk in a fresh instance."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        try:
+            documents_embeddings = [
+                torch.randn(80, 128, device="cpu") for _ in range(60)
+            ]
+            queries_embeddings = torch.randn(3, 30, 128, device="cpu")
+
+            index.create(documents_embeddings=documents_embeddings, kmeans_niters=4)
+            index.freeze()
+            results_before = index.search(
+                queries_embeddings=queries_embeddings, top_k=10
+            )
+        finally:
+            index.close()
+
+        reloaded = search.FastPlaid(index=test_index_path, device="cpu")
+        try:
+            results_after = reloaded.search(
+                queries_embeddings=queries_embeddings, top_k=10
+            )
+            assert results_before == results_after
+        finally:
+            reloaded.close()
+
+    def test_freeze_update_raises(self, test_index_path):
+        """update() on a frozen index must fail loudly rather than corrupt it."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        try:
+            documents_embeddings = [
+                torch.randn(60, 128, device="cpu") for _ in range(40)
+            ]
+            index.create(documents_embeddings=documents_embeddings, kmeans_niters=4)
+            index.freeze()
+
+            new_embeddings = [torch.randn(60, 128, device="cpu") for _ in range(10)]
+            with pytest.raises(RuntimeError, match="frozen"):
+                index.update(documents_embeddings=new_embeddings)
+        finally:
+            index.close()
+
+    def test_freeze_delete_raises(self, test_index_path):
+        """delete() on a frozen index must fail loudly."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        try:
+            documents_embeddings = [
+                torch.randn(60, 128, device="cpu") for _ in range(40)
+            ]
+            index.create(documents_embeddings=documents_embeddings, kmeans_niters=4)
+            index.freeze()
+
+            with pytest.raises(RuntimeError, match="frozen"):
+                index.delete(subset=[0, 1, 2])
+        finally:
+            index.close()
+
+    def test_freeze_idempotent(self, test_index_path):
+        """Calling freeze() twice should be a no-op the second time."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        try:
+            documents_embeddings = [
+                torch.randn(60, 128, device="cpu") for _ in range(40)
+            ]
+            index.create(documents_embeddings=documents_embeddings, kmeans_niters=4)
+            index.freeze()
+            index.freeze()  # second call: must not raise
+        finally:
+            index.close()
+
+
 # Legacy test function for backwards compatibility
 def test():
     """Ensure that the Fast-PLAiD search index can be created and queried correctly."""

--- a/tests/test.py
+++ b/tests/test.py
@@ -1477,6 +1477,110 @@ class TestFreeze:
         finally:
             index.close()
 
+    def test_freeze_unfreeze_roundtrip_byte_identical(self, tmp_path):
+        """freeze() then unfreeze() must restore every file byte-for-byte.
+
+        Build an index with several shards, snapshot its directory, then
+        freeze and unfreeze the original. Every file in the unfrozen index
+        must match the snapshot exactly (modulo merged_*.manifest.json,
+        which is a cache of mtimes regenerated on load).
+        """
+        import filecmp
+        import gc
+        import shutil
+
+        original_path = str(tmp_path / "original")
+        snapshot_path = str(tmp_path / "snapshot")
+        os.makedirs(original_path, exist_ok=True)
+
+        try:
+            index = search.FastPlaid(index=original_path, device="cpu")
+            # Force several shards so the roundtrip exercises real chunking.
+            documents_embeddings = [
+                torch.randn(80, 128, device="cpu") for _ in range(120)
+            ]
+            index.create(
+                documents_embeddings=documents_embeddings,
+                kmeans_niters=4,
+                batch_size=40,
+            )
+            index.close()
+            gc.collect()
+
+            # Snapshot the pristine on-disk index.
+            shutil.copytree(original_path, snapshot_path)
+
+            # Round-trip: freeze then unfreeze the original.
+            index = search.FastPlaid(index=original_path, device="cpu")
+            index.freeze()
+            index.unfreeze()
+            index.close()
+            gc.collect()
+
+            # Manifests are mtime caches, not source data; ignored intentionally.
+            ignored = {"merged_codes.manifest.json", "merged_residuals.manifest.json"}
+
+            original_files = {
+                f for f in os.listdir(original_path) if f not in ignored
+            }
+            snapshot_files = {
+                f for f in os.listdir(snapshot_path) if f not in ignored
+            }
+            assert original_files == snapshot_files, (
+                f"file set diverged: only-in-original={original_files - snapshot_files}, "
+                f"only-in-snapshot={snapshot_files - original_files}"
+            )
+
+            mismatches = []
+            for name in sorted(original_files):
+                a = os.path.join(original_path, name)
+                b = os.path.join(snapshot_path, name)
+                if not filecmp.cmp(a, b, shallow=False):
+                    mismatches.append(name)
+
+            assert mismatches == [], (
+                f"freeze/unfreeze roundtrip changed file bytes: {mismatches}"
+            )
+        finally:
+            shutil.rmtree(original_path, ignore_errors=True)
+            shutil.rmtree(snapshot_path, ignore_errors=True)
+
+    def test_unfreeze_restores_update_capability(self, test_index_path):
+        """After unfreeze() the index must accept update() again."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        try:
+            documents_embeddings = [
+                torch.randn(60, 128, device="cpu") for _ in range(40)
+            ]
+            index.create(documents_embeddings=documents_embeddings, kmeans_niters=4)
+            index.freeze()
+            index.unfreeze()
+
+            new_embeddings = [torch.randn(60, 128, device="cpu") for _ in range(10)]
+            index.update(documents_embeddings=new_embeddings)
+
+            queries = torch.randn(2, 30, 128, device="cpu")
+            results = index.search(queries_embeddings=queries, top_k=10)
+            for query_results in results:
+                for doc_id, _ in query_results:
+                    assert 0 <= doc_id < 50
+        finally:
+            index.close()
+
+    def test_unfreeze_idempotent(self, test_index_path):
+        """Calling unfreeze() on a non-frozen index is a no-op."""
+        index = search.FastPlaid(index=test_index_path, device="cpu")
+
+        try:
+            documents_embeddings = [
+                torch.randn(60, 128, device="cpu") for _ in range(40)
+            ]
+            index.create(documents_embeddings=documents_embeddings, kmeans_niters=4)
+            index.unfreeze()  # never frozen → no-op, must not raise
+        finally:
+            index.close()
+
 
 # Legacy test function for backwards compatibility
 def test():


### PR DESCRIPTION
## Summary
- Adds `FastPlaid.freeze()` which deletes the per-shard `{i}.codes.npy` / `{i}.residuals.npy` files and sets `"frozen": true` in `metadata.json`. The merged file remains and becomes the sole storage, cutting on-disk usage roughly in half.
- Adds `FastPlaid.unfreeze()` as the inverse: slices `merged_codes.npy` / `merged_residuals.npy` back into per-shard files using `doclens.{i}.json`, then drops the `frozen` key. The roundtrip is **byte-identical** — every file matches the original.
- Teaches the loader to skip the chunk scan when an index is frozen and `mmap` the merged file directly (slightly faster reload, less peak RAM).
- `update()` and `delete()` on a frozen index raise `RuntimeError` — both paths operate per shard and can't run without re-sharding (call `unfreeze()` first).

## Motivation
After indexing, FastPlaid keeps two copies of the same compressed data on disk:
- per-shard `{i}.codes.npy` / `{i}.residuals.npy` (used by `update.rs` / `delete.rs`)
- a merged `merged_codes.npy` / `merged_residuals.npy` (used at search time via `StridedTensor`)

For workloads that won't mutate the index again, the shards are dead weight. `freeze()` makes that explicit and reclaims the space without any Rust changes. `unfreeze()` is there as an escape hatch if you change your mind.

## Byte-identical roundtrip
`unfreeze()` reconstructs shards via a small helper that matches `tch::Tensor::write_npy` byte-for-byte:
- Rust-style shape formatting `(R,C,)` (trailing comma, no spaces) instead of `np.save`'s `(R, C)`.
- Explicit `<` byte order even for 1-byte types (`np.save` writes `|`).
- Header padded so the prologue (10 + header) is a multiple of 16, matching tch's alignment.

`metadata.json` is written with `indent=2` to match `serde_json::to_writer_pretty`. The `frozen` key is fully removed on `unfreeze()` so the file matches its pre-freeze bytes exactly.

## What's untouched
- Indexing path (`create.rs`) and the chunk-then-merge flow are unchanged. Peak RAM during create is preserved.
- Search hot path is identical — same merged mmap, same `StridedTensor`.
- Non-frozen indexes behave exactly as before.

## Test plan
- [x] `test_freeze_removes_shards_and_search_still_works` — search results identical before and after `freeze()`, shard files gone, merged files retained.
- [x] `test_freeze_persists_across_reload` — a frozen index reopens correctly in a new `FastPlaid` instance and returns the same results.
- [x] `test_freeze_update_raises` — `update()` on a frozen index raises `RuntimeError`.
- [x] `test_freeze_delete_raises` — `delete()` on a frozen index raises `RuntimeError`.
- [x] `test_freeze_idempotent` — calling `freeze()` twice is a no-op.
- [x] `test_freeze_unfreeze_roundtrip_byte_identical` — create a multi-shard index, copy the directory, freeze+unfreeze the original, assert every file is byte-identical to the snapshot via `filecmp.cmp(shallow=False)`.
- [x] `test_unfreeze_restores_update_capability` — after `unfreeze()`, `update()` works again.
- [x] `test_unfreeze_idempotent` — calling `unfreeze()` on a non-frozen index is a no-op.
- [x] Existing `TestBasicCreateAndSearch` and `TestUpdate` suites still pass.