### PR TITLE
Fix long-context search OOMs, improve search speed with auto batching, add index auto device placement

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -29,4 +29,4 @@ jobs:
         run: uv pip install ruff
 
       - name: Check Python code with ruff
-        run: uv run ruff check python
+        run: uv run --no-project ruff check python

--- a/python/fast_plaid/search/fast_plaid.py
+++ b/python/fast_plaid/search/fast_plaid.py
@@ -726,7 +726,7 @@ class FastPlaid:
             # per-device GPU loads to the first search (all-None entries reload lazily).
             _load_index_tensors_cpu(index_path=self.index)
             with self._index_swap_lock:
-                self.indices = {device: None for device in self.devices}
+                self.indices = dict.fromkeys(self.devices)
                 self._update_mtime()
 
         return self
@@ -834,8 +834,7 @@ class FastPlaid:
             shape_str = "(" + ",".join(str(s) for s in arr.shape) + ",)"
 
         header_body = (
-            f"{{'descr': '{descr}', 'fortran_order': False, "
-            f"'shape': {shape_str}, }}"
+            f"{{'descr': '{descr}', 'fortran_order': False, 'shape': {shape_str}, }}"
         )
 
         prologue_fixed = 10  # magic(6) + version(2) + header_len_field(2)

--- a/python/fast_plaid/search/fast_plaid.py
+++ b/python/fast_plaid/search/fast_plaid.py
@@ -8,7 +8,7 @@ import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     import types
@@ -23,7 +23,7 @@ from joblib import Parallel, delayed
 
 from ..filtering import create, delete
 from .kmeans import FastKMeans
-from .load import _reload_index, save_list_tensors_on_disk
+from .load import _load_index_tensors_cpu, _reload_index, save_list_tensors_on_disk
 from .update import process_update
 
 
@@ -185,15 +185,81 @@ def compute_kmeans(
     ).half()
 
 
+def device_memory_budget(device: str, search_memory_fraction: float) -> int:
+    """Scoring budget in bytes: `search_memory_fraction` of free VRAM; 0 on CPU."""
+    if device.startswith("cuda") and torch.cuda.is_available():
+        free, _ = torch.cuda.mem_get_info(torch.device(device))
+        return int(free * search_memory_fraction)
+    return 0
+
+
+def _resolve_batch_size(batch_size: int | Literal["auto"]) -> int:
+    """Map 'auto' to 0 (memory-planned chunks); validate manual chunk sizes."""
+    if batch_size == "auto":
+        return 0
+    if not isinstance(batch_size, int) or batch_size <= 0:
+        raise ValueError("batch_size must be 'auto' or a positive int.")
+    return batch_size
+
+
+def _true_query_lengths(queries: list[torch.Tensor]) -> list[int]:
+    """Last non-zero row + 1 per query (min 1), vectorized over same-shape chunks."""
+    lengths: list[int] = []
+    start = 0
+    n = len(queries)
+    chunk = 256
+    while start < n:
+        # Group contiguous equal-shaped queries (PyLate pads all to query_length).
+        shape = queries[start].shape
+        end = start + 1
+        limit = min(start + chunk, n)
+        while end < limit and queries[end].shape == shape:
+            end += 1
+        stacked = torch.stack(queries[start:end])
+        row_is_nonzero = (stacked != 0).any(dim=-1)
+        positions = torch.arange(
+            1, row_is_nonzero.shape[1] + 1, device=row_is_nonzero.device
+        )
+        chunk_lengths = (row_is_nonzero * positions).amax(dim=1).clamp_min(1)
+        lengths.extend(int(v) for v in chunk_lengths.tolist())
+        start = end
+    return lengths
+
+
+def pack_queries(
+    queries_embeddings: torch.Tensor | list[torch.Tensor],
+) -> tuple[torch.Tensor, list[int]]:
+    """Trim per-query zero-row padding and pack into a [total_tokens, dim] fp16 tensor.
+
+    Returns the packed tensor and the true token count per query.
+    """
+    if isinstance(queries_embeddings, torch.Tensor):
+        if queries_embeddings.dim() == 2:
+            queries_embeddings = [queries_embeddings]
+        else:
+            queries_embeddings = list(queries_embeddings.unbind(0))
+
+    queries = [q.squeeze(0) if q.dim() == 3 else q for q in queries_embeddings]
+    if not queries:
+        return torch.empty(0, 0, dtype=torch.float16), []
+
+    lengths = _true_query_lengths(queries)
+    pieces = [q[:length] for q, length in zip(queries, lengths)]
+    packed = torch.cat(pieces, dim=0)
+    return packed.to(torch.float16), lengths
+
+
 def search_on_device(
     device: str,
     queries_embeddings: torch.Tensor,
-    batch_size: int,
+    batch_size: int | Literal["auto"],
     n_full_scores: int,
     top_k: int,
     n_ivf_probe: int,
+    search_memory_fraction: float,
     index_object: Any,
     show_progress: bool,
+    query_lengths: list[int],
     subset: list[list[int]] | None = None,
 ) -> list[list[tuple[int, float]]]:
     """Perform a search on a single specified device using the passed object.
@@ -203,19 +269,24 @@ def search_on_device(
     device:
         The device identifier to perform the search on.
     queries_embeddings:
-        The query embeddings to search for.
+        A packed 2D tensor (total_query_tokens, embedding_dim) holding all
+        queries concatenated without padding.
     batch_size:
-        The batch size for processing queries.
+        Documents per scoring chunk; 'auto' plans chunks from the memory budget.
     n_full_scores:
         The number of full scores to compute per query.
     top_k:
         The number of top results to return.
     n_ivf_probe:
         The number of IVF clusters to probe.
+    search_memory_fraction:
+        Fraction of free VRAM the scoring stages may use.
     index_object:
         The loaded index object for the specific device.
     show_progress:
         Whether to show a progress bar.
+    query_lengths:
+        True token count per query in the packed tensor.
     subset:
         Optional subset of document IDs to search within.
 
@@ -229,10 +300,11 @@ def search_on_device(
         raise ValueError(error)
 
     search_parameters = fast_plaid_rust.SearchParameters(
-        batch_size=batch_size,
+        batch_size=_resolve_batch_size(batch_size),
         n_full_scores=n_full_scores,
         top_k=top_k,
         n_ivf_probe=n_ivf_probe,
+        memory_budget_bytes=device_memory_budget(device, search_memory_fraction),
     )
 
     scores = fast_plaid_rust.pysearch(
@@ -242,6 +314,7 @@ def search_on_device(
         search_parameters=search_parameters,
         show_progress=show_progress,
         subset=subset,
+        query_lengths=query_lengths,
     )
 
     return [
@@ -256,12 +329,14 @@ def search_on_device(
 def search_on_device_with_token_scores(
     device: str,
     queries_embeddings: torch.Tensor,
-    batch_size: int,
+    batch_size: int | Literal["auto"],
     n_full_scores: int,
     top_k: int,
     n_ivf_probe: int,
+    search_memory_fraction: float,
     index_object: Any,
     show_progress: bool,
+    query_lengths: list[int],
     subset: list[list[int]] | None = None,
 ) -> list[list[tuple[int, float, torch.Tensor]]]:
     """Perform a search on a single device, returning token-level similarity matrices.
@@ -273,17 +348,21 @@ def search_on_device_with_token_scores(
     queries_embeddings:
         The query embeddings to search for.
     batch_size:
-        The batch size for processing queries.
+        Documents per scoring chunk; 'auto' plans chunks from the memory budget.
     n_full_scores:
         The number of full scores to compute per query.
     top_k:
         The number of top results to return.
     n_ivf_probe:
         The number of IVF clusters to probe.
+    search_memory_fraction:
+        Fraction of free VRAM the scoring stages may use.
     index_object:
         The loaded index object for the specific device.
     show_progress:
         Whether to show a progress bar.
+    query_lengths:
+        True token count per query in the packed tensor.
     subset:
         Optional subset of document IDs to search within.
 
@@ -296,10 +375,11 @@ def search_on_device_with_token_scores(
         raise ValueError(error)
 
     search_parameters = fast_plaid_rust.SearchParameters(
-        batch_size=batch_size,
+        batch_size=_resolve_batch_size(batch_size),
         n_full_scores=n_full_scores,
         top_k=top_k,
         n_ivf_probe=n_ivf_probe,
+        memory_budget_bytes=device_memory_budget(device, search_memory_fraction),
     )
 
     results = fast_plaid_rust.pysearch_with_token_scores(
@@ -309,6 +389,7 @@ def search_on_device_with_token_scores(
         search_parameters=search_parameters,
         show_progress=show_progress,
         subset=subset,
+        query_lengths=query_lengths,
     )
 
     return [
@@ -329,7 +410,9 @@ class FastPlaid:
         self,
         index: str,
         device: str | list[str] | None = None,
-        low_memory: bool = True,
+        index_gpu_memory: Literal["auto", "low", "medium", "high"] = "auto",
+        index_memory_fraction: float = 0.7,
+        search_memory_fraction: float = 0.5,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
         """Initialize the FastPlaid instance.
@@ -340,12 +423,27 @@ class FastPlaid:
             Path to the directory where the index is stored.
         device:
             The device(s) to use for index operations (e.g., 'cuda:0', 'cpu').
-        low_memory:
-            Whether to use low memory mode when loading the index.
+        index_gpu_memory:
+            GPU placement of the large document tensors: 'low' keeps codes and
+            residuals on CPU, 'medium' moves codes to GPU, 'high' moves both;
+            'auto' picks the highest tier that fits within index_memory_fraction
+            of the device. Placement affects speed only.
+        index_memory_fraction:
+            Fraction of device memory 'auto' index placement may fill.
+        search_memory_fraction:
+            Fraction of free VRAM the scoring stages may use when batch_size
+            is 'auto'.
         kwargs:
             Additional keyword arguments.
 
         """
+        if index_gpu_memory not in {"auto", "low", "medium", "high"}:
+            error = "index_gpu_memory must be 'auto', 'low', 'medium' or 'high'."
+            raise ValueError(error)
+        if not 0.0 < index_memory_fraction <= 1.0:
+            raise ValueError("index_memory_fraction must be in (0, 1].")
+        if not 0.0 < search_memory_fraction <= 1.0:
+            raise ValueError("search_memory_fraction must be in (0, 1].")
         if device is not None and isinstance(device, str):
             self.devices = [device]
         elif isinstance(device, list):
@@ -363,7 +461,9 @@ class FastPlaid:
 
         self.torch_path = _load_torch_path(device=self.devices[0])
         self.index = index
-        self.low_memory = low_memory
+        self.index_gpu_memory = index_gpu_memory
+        self.index_memory_fraction = index_memory_fraction
+        self.search_memory_fraction = search_memory_fraction
 
         # Concurrency Control
         if not os.path.exists(self.index):
@@ -503,7 +603,8 @@ class FastPlaid:
             index_path=self.index,
             devices=self.devices,
             indices=self.indices,
-            low_memory=self.low_memory,
+            index_gpu_memory=self.index_gpu_memory,
+            index_memory_fraction=self.index_memory_fraction,
         )
 
         # Atomic swap of indices dictionary
@@ -621,17 +722,11 @@ class FastPlaid:
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
-            # Reload indices on all devices now that creation is complete
-            new_indices = _reload_index(
-                index_path=self.index,
-                devices=self.devices,
-                indices={},
-                low_memory=self.low_memory,
-            )
-
-            # Atomic swap of indices dictionary
+            # Materialize the merged on-disk files once (CPU-side); defer the
+            # per-device GPU loads to the first search (all-None entries reload lazily).
+            _load_index_tensors_cpu(index_path=self.index)
             with self._index_swap_lock:
-                self.indices = new_indices
+                self.indices = {device: None for device in self.devices}
                 self._update_mtime()
 
         return self
@@ -890,7 +985,8 @@ class FastPlaid:
                 index_path=self.index,
                 devices=self.devices,
                 torch_path=self.torch_path,
-                low_memory=self.low_memory,
+                index_gpu_memory=self.index_gpu_memory,
+                index_memory_fraction=self.index_memory_fraction,
                 indices_dict=current_indices,
                 documents_embeddings=documents_embeddings,
                 metadata=metadata,
@@ -947,8 +1043,8 @@ class FastPlaid:
         self,
         queries_embeddings: torch.Tensor | list[torch.Tensor],
         subset: list[list[int]] | list[int] | None,
-    ) -> tuple[dict[str, Any], torch.Tensor, list[list[int]] | None]:
-        """Shared setup for search methods: reload index, validate, normalize inputs."""
+    ) -> tuple[dict[str, Any], torch.Tensor, list[int], list[list[int]] | None]:
+        """Shared setup for search methods: reload index, validate, pack queries."""
         self._check_and_reload_index(blocking=False)
 
         with self._index_swap_lock:
@@ -972,17 +1068,8 @@ class FastPlaid:
                 Check CUDA memory or device availability."""
                 raise RuntimeError(error)
 
-        if isinstance(queries_embeddings, list):
-            queries_embeddings = torch.nn.utils.rnn.pad_sequence(
-                sequences=[
-                    embedding[0] if embedding.dim() == 3 else embedding
-                    for embedding in queries_embeddings
-                ],
-                batch_first=True,
-                padding_value=0.0,
-            )
-
-        num_queries = queries_embeddings.shape[0]
+        packed_queries, query_lengths = pack_queries(queries_embeddings)
+        num_queries = len(query_lengths)
 
         if subset is not None:
             if isinstance(subset, int):
@@ -995,16 +1082,17 @@ class FastPlaid:
             if subset is not None and len(subset) != num_queries:
                 raise ValueError("Subset length must match number of queries.")
 
-        return search_indices, queries_embeddings, subset  # type: ignore
+        return search_indices, packed_queries, query_lengths, subset  # type: ignore
 
     def _dispatch_search(
         self,
         device_fn: Any,
         search_indices: dict[str, Any],
-        queries_embeddings: torch.Tensor,
+        packed_queries: torch.Tensor,
+        query_lengths: list[int],
         subset: list[list[int]] | None,
         *,
-        batch_size: int,
+        batch_size: int | Literal["auto"],
         n_full_scores: int,
         top_k: int,
         n_ivf_probe: int,
@@ -1020,12 +1108,14 @@ class FastPlaid:
             search_on_device_with_token_scores).
         search_indices:
             Mapping of device name to loaded index object.
-        queries_embeddings:
-            A 3D tensor of query embeddings (num_queries, n_tokens, embedding_dim).
+        packed_queries:
+            A 2D packed tensor (total_query_tokens, embedding_dim), no padding.
+        query_lengths:
+            True token count per query.
         subset:
             Optional per-query document ID filters.
         batch_size:
-            The number of queries to process in each batch.
+            Documents per scoring chunk; 'auto' plans chunks from the memory budget.
         n_full_scores:
             The number of full scores to compute per query.
         top_k:
@@ -1039,7 +1129,20 @@ class FastPlaid:
             Ignored on GPU. Defaults to 1.
 
         """
-        num_queries = queries_embeddings.shape[0]
+        num_queries = len(query_lengths)
+        if num_queries == 0:
+            return []
+
+        token_offsets = [0]
+        for length in query_lengths:
+            token_offsets.append(token_offsets[-1] + length)
+
+        def query_slice(q_start: int, q_end: int) -> tuple[torch.Tensor, list[int]]:
+            t_start, t_end = token_offsets[q_start], token_offsets[q_end]
+            return (
+                packed_queries.narrow(0, t_start, t_end - t_start),
+                query_lengths[q_start:q_end],
+            )
 
         # Joblib parallelism for CPU-only bulk search
         is_cpu_only = self.devices[0] == "cpu"
@@ -1056,71 +1159,84 @@ class FastPlaid:
         if use_joblib:
             num_workers = n_processes
             chunk_size = math.ceil(num_queries / num_workers)
-            query_chunks = list(torch.split(queries_embeddings, chunk_size))
+            bounds = [
+                (start, min(start + chunk_size, num_queries))
+                for start in range(0, num_queries, chunk_size)
+            ]
             subset_chunks: list = []
             if subset is not None:
-                for i in range(0, num_queries, chunk_size):
-                    subset_chunks.append(subset[i : i + chunk_size])
+                subset_chunks = [subset[start:end] for start, end in bounds]
             else:
-                subset_chunks = [None] * len(query_chunks)  # type: ignore
+                subset_chunks = [None] * len(bounds)  # type: ignore
 
             results = Parallel(n_jobs=num_workers, prefer="threads")(
                 delayed(device_fn)(
                     device="cpu",
-                    queries_embeddings=chunk,
+                    queries_embeddings=query_slice(start, end)[0],
                     batch_size=batch_size,
                     n_full_scores=n_full_scores,
                     top_k=top_k,
                     n_ivf_probe=n_ivf_probe,
+                    search_memory_fraction=self.search_memory_fraction,
                     index_object=search_indices["cpu"],
                     show_progress=(show_progress and i == 0),
                     subset=sub_chunk,
+                    query_lengths=query_slice(start, end)[1],
                 )
-                for i, (chunk, sub_chunk) in enumerate(zip(query_chunks, subset_chunks))
+                for i, ((start, end), sub_chunk) in enumerate(
+                    zip(bounds, subset_chunks)
+                )
             )
             return [item for sublist in results for item in sublist]
 
         if len(self.devices) == 1:
             return device_fn(
                 device=self.devices[0],
-                queries_embeddings=queries_embeddings,
+                queries_embeddings=packed_queries,
                 batch_size=batch_size,
                 n_full_scores=n_full_scores,
                 top_k=top_k,
                 n_ivf_probe=n_ivf_probe,
+                search_memory_fraction=self.search_memory_fraction,
                 index_object=search_indices[self.devices[0]],
                 show_progress=show_progress,
                 subset=subset,
+                query_lengths=query_lengths,
             )
 
         # Multi-GPU split
         num_devices = len(self.devices)
         chunk_size = math.ceil(num_queries / num_devices)
-        query_chunks = list(torch.split(queries_embeddings, chunk_size))
+        bounds = [
+            (start, min(start + chunk_size, num_queries))
+            for start in range(0, num_queries, chunk_size)
+        ]
         subset_chunks_gpu: list = []
         if subset is not None:
-            for i in range(0, num_queries, chunk_size):
-                subset_chunks_gpu.append(subset[i : i + chunk_size])
+            subset_chunks_gpu = [subset[start:end] for start, end in bounds]
         else:
-            subset_chunks_gpu = [None] * len(query_chunks)  # type: ignore
+            subset_chunks_gpu = [None] * len(bounds)  # type: ignore
 
         futures = []
         with ThreadPoolExecutor(max_workers=num_devices) as executor:
             for i, device in enumerate(self.devices):
-                if i >= len(query_chunks):
+                if i >= len(bounds):
                     break
+                chunk_queries, chunk_lengths = query_slice(*bounds[i])
                 futures.append(
                     executor.submit(
                         device_fn,
                         device=device,
-                        queries_embeddings=query_chunks[i],
+                        queries_embeddings=chunk_queries,
                         batch_size=batch_size,
                         n_full_scores=n_full_scores,
                         top_k=top_k,
                         n_ivf_probe=n_ivf_probe,
+                        search_memory_fraction=self.search_memory_fraction,
                         index_object=search_indices[device],
                         show_progress=show_progress and (i == 0),
                         subset=subset_chunks_gpu[i],
+                        query_lengths=chunk_lengths,
                     )
                 )
 
@@ -1135,7 +1251,7 @@ class FastPlaid:
         self,
         queries_embeddings: torch.Tensor | list[torch.Tensor],
         top_k: int = 10,
-        batch_size: int = 2000,
+        batch_size: int | Literal["auto"] = "auto",
         n_full_scores: int = 4096,
         n_ivf_probe: int = 8,
         show_progress: bool = True,
@@ -1152,7 +1268,8 @@ class FastPlaid:
         top_k:
             The number of top results to return for each query.
         batch_size:
-            The number of queries to process in each batch.
+            Documents per scoring chunk; 'auto' plans chunks from the device
+            memory budget.
         n_full_scores:
             The number of full scores to compute per query.
         n_ivf_probe:
@@ -1168,14 +1285,15 @@ class FastPlaid:
             Ignored if running on GPU(s). Defaults to 1.
 
         """
-        search_indices, queries_embeddings, subset = self._prepare_search(
+        search_indices, packed_queries, query_lengths, subset = self._prepare_search(
             queries_embeddings, subset
         )
 
         return self._dispatch_search(
             search_on_device,
             search_indices,
-            queries_embeddings,
+            packed_queries,
+            query_lengths,
             subset,  # type: ignore
             batch_size=batch_size,
             n_full_scores=n_full_scores,
@@ -1190,7 +1308,7 @@ class FastPlaid:
         self,
         queries_embeddings: torch.Tensor | list[torch.Tensor],
         top_k: int = 10,
-        batch_size: int = 2000,
+        batch_size: int | Literal["auto"] = "auto",
         n_full_scores: int = 4096,
         n_ivf_probe: int = 8,
         show_progress: bool = True,
@@ -1212,7 +1330,8 @@ class FastPlaid:
         top_k:
             The number of top results to return for each query.
         batch_size:
-            The number of queries to process in each batch.
+            Documents per scoring chunk; 'auto' plans chunks from the device
+            memory budget.
         n_full_scores:
             The number of full scores to compute per query.
         n_ivf_probe:
@@ -1228,14 +1347,15 @@ class FastPlaid:
             Ignored if running on GPU(s). Defaults to 1.
 
         """
-        search_indices, queries_embeddings, subset = self._prepare_search(
+        search_indices, packed_queries, query_lengths, subset = self._prepare_search(
             queries_embeddings, subset
         )
 
         return self._dispatch_search(
             search_on_device_with_token_scores,
             search_indices,
-            queries_embeddings,
+            packed_queries,
+            query_lengths,
             subset,  # type: ignore
             batch_size=batch_size,
             n_full_scores=n_full_scores,
@@ -1350,7 +1470,8 @@ class FastPlaid:
                 index_path=self.index,
                 devices=self.devices,
                 indices={},
-                low_memory=self.low_memory,
+                index_gpu_memory=self.index_gpu_memory,
+                index_memory_fraction=self.index_memory_fraction,
             )
 
             # Atomic swap of indices dictionary

--- a/python/fast_plaid/search/load.py
+++ b/python/fast_plaid/search/load.py
@@ -359,8 +359,35 @@ def _load_index_tensors_cpu(index_path: str) -> dict[str, Any] | None:
     return data
 
 
+def _resolve_index_gpu_memory(
+    data: dict[str, Any],
+    device: str,
+    index_gpu_memory: str,
+    index_memory_fraction: float,
+) -> str:
+    """Resolve 'auto' to the highest tier within `index_memory_fraction` of VRAM."""
+    if index_gpu_memory != "auto":
+        return index_gpu_memory
+    if not device.startswith("cuda") or not torch.cuda.is_available():
+        return "low"
+
+    free, total = torch.cuda.mem_get_info(torch.device(device))
+    codes_bytes = data["doc_codes"].numel() * 8  # stored as int64
+    residuals_bytes = data["doc_residuals"].numel()  # uint8
+    headroom = int((1.0 - index_memory_fraction) * total)
+
+    if free - (codes_bytes + residuals_bytes) >= headroom:
+        return "high"
+    if free - codes_bytes >= headroom:
+        return "medium"
+    return "low"
+
+
 def _construct_index_from_tensors(
-    data: dict[str, Any], device: str, low_memory: bool
+    data: dict[str, Any],
+    device: str,
+    index_gpu_memory: str,
+    index_memory_fraction: float,
 ) -> Any:
     """Build Rust index from CPU tensors.
 
@@ -370,16 +397,23 @@ def _construct_index_from_tensors(
         Dictionary of tensors loaded on CPU.
     device:
         The target device for the index.
-    low_memory:
-        If True, keeps large document tensors on CPU to save VRAM.
+    index_gpu_memory:
+        GPU placement tier for the large document tensors; 'auto' adapts per device.
+    index_memory_fraction:
+        Fraction of device memory 'auto' placement may fill.
 
     """
+    index_gpu_memory = _resolve_index_gpu_memory(
+        data, device, index_gpu_memory, index_memory_fraction
+    )
+
     gpu_data: dict[str, Any] = {}
     for key, val in data.items():
         if val is None:
             gpu_data[key] = None
         elif isinstance(val, torch.Tensor):
-            if low_memory and key in ["doc_codes", "doc_residuals", "doc_lengths"]:
+            if key in ["doc_codes", "doc_residuals", "doc_lengths"]:
+                # Tier placement happens on the Rust side; hand these over on CPU.
                 gpu_data[key] = val
             else:
                 gpu_data[key] = val.to(device, non_blocking=True)
@@ -398,7 +432,7 @@ def _construct_index_from_tensors(
         doc_residuals=gpu_data["doc_residuals"],
         doc_lengths=gpu_data["doc_lengths"],
         device=device,
-        low_memory=low_memory,
+        index_gpu_memory=index_gpu_memory,
     )
 
 
@@ -406,7 +440,8 @@ def _reload_index(
     index_path: str,
     devices: list[str],
     indices: dict[str, Any],
-    low_memory: bool = False,
+    index_gpu_memory: str = "auto",
+    index_memory_fraction: float = 0.7,
 ) -> dict[str, Any]:
     """Load or reload the index for all configured devices.
 
@@ -418,8 +453,10 @@ def _reload_index(
         List of devices to load the index on.
     indices:
         Dictionary mapping devices to index objects.
-    low_memory:
-        If True, keeps large document tensors on CPU.
+    index_gpu_memory:
+        GPU placement tier for the large document tensors; 'auto' adapts per device.
+    index_memory_fraction:
+        Fraction of device memory 'auto' placement may fill.
 
     """
     if not os.path.exists(os.path.join(index_path, "metadata.json")):
@@ -445,7 +482,8 @@ def _reload_index(
             idx = _construct_index_from_tensors(
                 data=cpu_tensors,  # noqa: F821
                 device=device,
-                low_memory=low_memory,
+                index_gpu_memory=index_gpu_memory,
+                index_memory_fraction=index_memory_fraction,
             )
             return device, idx  # noqa: TRY300
         except Exception as e:

--- a/python/fast_plaid/search/update.py
+++ b/python/fast_plaid/search/update.py
@@ -27,7 +27,8 @@ def partial_reload(
     index_path: str,
     devices: list[str],
     indices_dict: dict[str, Any],
-    low_memory: bool,
+    index_gpu_memory: str,
+    index_memory_fraction: float,
 ) -> dict[str, Any]:
     """Reload index data after update.
 
@@ -39,8 +40,10 @@ def partial_reload(
         List of devices to reload the index on.
     indices_dict:
         Dictionary mapping devices to index objects, updated in place.
-    low_memory:
-        Whether to use low memory mode when loading.
+    index_gpu_memory:
+        GPU placement tier for the large document tensors; 'auto' adapts per device.
+    index_memory_fraction:
+        Fraction of device memory 'auto' placement may fill.
 
     """
     # Clear old indices first to release memory-mapped file handles
@@ -56,7 +59,8 @@ def partial_reload(
         indices_dict[device] = _construct_index_from_tensors(
             data=cpu_tensors,
             device=device,
-            low_memory=low_memory,
+            index_gpu_memory=index_gpu_memory,
+            index_memory_fraction=index_memory_fraction,
         )
 
     return indices_dict
@@ -207,7 +211,8 @@ def process_update(
     index_path: str,
     devices: list[str],
     torch_path: str,
-    low_memory: bool,
+    index_gpu_memory: str,
+    index_memory_fraction: float,
     indices_dict: dict[str, Any],
     documents_embeddings: list[torch.Tensor] | torch.Tensor,
     metadata: list[dict[str, Any]] | None,
@@ -234,8 +239,10 @@ def process_update(
         List of devices to use for the update.
     torch_path:
         Path to the torch shared library.
-    low_memory:
-        Whether to use low memory mode when loading.
+    index_gpu_memory:
+        GPU placement tier for the large document tensors; 'auto' adapts per device.
+    index_memory_fraction:
+        Fraction of device memory 'auto' placement may fill.
     indices_dict:
         Dictionary mapping devices to index objects.
     documents_embeddings:
@@ -286,7 +293,8 @@ def process_update(
             index_path=index_path,
             devices=devices,
             indices={},
-            low_memory=low_memory,
+            index_gpu_memory=index_gpu_memory,
+            index_memory_fraction=index_memory_fraction,
         )
 
     documents_embeddings = format_embeddings_fn(documents_embeddings)
@@ -345,7 +353,8 @@ def process_update(
             index_path=index_path,
             devices=devices,
             indices={},
-            low_memory=low_memory,
+            index_gpu_memory=index_gpu_memory,
+            index_memory_fraction=index_memory_fraction,
         )
 
     # Ensure index is loaded before update
@@ -354,7 +363,8 @@ def process_update(
             index_path=index_path,
             devices=devices,
             indices=indices_dict,
-            low_memory=low_memory,
+            index_gpu_memory=index_gpu_memory,
+            index_memory_fraction=index_memory_fraction,
         )
         indices_dict.clear()
         indices_dict.update(new_indices)
@@ -405,7 +415,8 @@ def process_update(
             index_path=index_path,
             devices=devices,
             indices=indices_dict,
-            low_memory=low_memory,
+            index_gpu_memory=index_gpu_memory,
+            index_memory_fraction=index_memory_fraction,
         )
 
         if os.path.exists(os.path.join(index_path, "buffer.npy")):
@@ -425,7 +436,8 @@ def process_update(
             index_path=index_path,
             devices=devices,
             indices_dict=indices_dict,
-            low_memory=low_memory,
+            index_gpu_memory=index_gpu_memory,
+            index_memory_fraction=index_memory_fraction,
         )
 
     # Buffer not reached - append to buffer and update without centroid expansion
@@ -448,5 +460,6 @@ def process_update(
         index_path=index_path,
         devices=devices,
         indices_dict=indices_dict,
-        low_memory=low_memory,
+        index_gpu_memory=index_gpu_memory,
+        index_memory_fraction=index_memory_fraction,
     )

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -176,11 +176,13 @@ fn create(
 ///     index (PyLoadedIndex): A reference to the loaded index object containing
 ///         IVF structures and codebooks.
 ///     device (str): Device to perform the search on (e.g., "cpu", "cuda:0").
-///     queries_embeddings (torch.Tensor): A 3D tensor of query embeddings
-///         with shape (num_queries, num_query_tokens, embedding_dim).
+///     queries_embeddings (torch.Tensor): A 2D packed tensor of shape
+///         (total_query_tokens, embedding_dim) holding all queries
+///         concatenated without padding.
 ///     search_parameters (SearchParameters): A SearchParameters object
 ///         containing `top_k`, `n_ivf_probe`, etc.
 ///     show_progress (bool): Whether to display a progress bar during search.
+///     query_lengths (list[int]): True token count per query in the packed tensor.
 ///     subset (list[list[int]] | None): An optional filter to restrict the
 ///         search. Must be a list of lists, where each inner list contains
 ///         the document IDs to search for that specific query.
@@ -192,6 +194,7 @@ fn create(
 ///     RuntimeError: If searching fails.
 ///     ValueError: If search parameters are invalid.
 #[pyfunction]
+#[pyo3(signature = (index, device, queries_embeddings, search_parameters, show_progress, query_lengths, subset=None))]
 fn pysearch(
     py: Python<'_>,
     index: &PyLoadedIndex,
@@ -199,6 +202,7 @@ fn pysearch(
     queries_embeddings: PyTensor,
     search_parameters: &SearchParameters,
     show_progress: bool,
+    query_lengths: Vec<i64>,
     subset: Option<Vec<Vec<i64>>>,
 ) -> PyResult<Vec<QueryResult>> {
     let device_tch = get_device(&device)?;
@@ -215,6 +219,7 @@ fn pysearch(
                 device_tch,
                 show_progress,
                 subset,
+                query_lengths,
             )
         })
         .map_err(anyhow_to_pyerr)?;
@@ -230,11 +235,13 @@ fn pysearch(
 /// Args:
 ///     index (PyLoadedIndex): A reference to the loaded index object.
 ///     device (str): Device to perform the search on (e.g., "cpu", "cuda:0").
-///     queries_embeddings (torch.Tensor): A 3D tensor of query embeddings
-///         with shape (num_queries, num_query_tokens, embedding_dim).
+///     queries_embeddings (torch.Tensor): A 2D packed tensor of shape
+///         (total_query_tokens, embedding_dim) holding all queries
+///         concatenated without padding.
 ///     search_parameters (SearchParameters): A SearchParameters object
 ///         containing `top_k`, `n_ivf_probe`, etc.
 ///     show_progress (bool): Whether to display a progress bar during search.
+///     query_lengths (list[int]): True token count per query in the packed tensor.
 ///     subset (list[list[int]] | None): An optional filter to restrict the
 ///         search per query.
 ///
@@ -245,6 +252,7 @@ fn pysearch(
 /// Raises:
 ///     RuntimeError: If searching fails.
 #[pyfunction]
+#[pyo3(signature = (index, device, queries_embeddings, search_parameters, show_progress, query_lengths, subset=None))]
 fn pysearch_with_token_scores(
     py: Python<'_>,
     index: &PyLoadedIndex,
@@ -252,6 +260,7 @@ fn pysearch_with_token_scores(
     queries_embeddings: PyTensor,
     search_parameters: &SearchParameters,
     show_progress: bool,
+    query_lengths: Vec<i64>,
     subset: Option<Vec<Vec<i64>>>,
 ) -> PyResult<Vec<QueryResultWithTokenScores>> {
     let device_tch = get_device(&device)?;
@@ -267,6 +276,7 @@ fn pysearch_with_token_scores(
                 device_tch,
                 show_progress,
                 subset,
+                query_lengths,
             )
         })
         .map_err(anyhow_to_pyerr)?;

--- a/rust/search/load.rs
+++ b/rust/search/load.rs
@@ -102,8 +102,8 @@ fn ensure_tensor(t: PyTensor, device: Device, kind: Kind) -> Tensor {
 ///   directly without allocation.
 /// - **Codec Handling**: Small tensors (centroids, weights) are loaded into RAM/VRAM
 ///   immediately for fast lookup during decompression.
-/// - **Low Memory Mode**: If `low_memory` is true, the large document tensors are strictly
-///   kept on the CPU, even if the target `device` is CUDA.
+/// - **GPU Memory Tiers**: `index_gpu_memory` places codes/residuals: "low" = both on CPU,
+///   "medium" = codes on GPU, "high" = both on GPU. Doc lengths always follow the search device.
 ///
 /// # Arguments
 ///
@@ -118,7 +118,7 @@ fn ensure_tensor(t: PyTensor, device: Device, kind: Kind) -> Tensor {
 /// * `doc_residuals` - The compressed document residuals (uint8).
 /// * `doc_lengths` - The true lengths of documents (int64).
 /// * `device` - The target device string (e.g. "cuda:0").
-/// * `low_memory` - If true, keeps document data on CPU.
+/// * `index_gpu_memory` - Placement tier: "low", "medium" or "high".
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
 pub fn construct_index(
@@ -134,12 +134,21 @@ pub fn construct_index(
     doc_residuals: PyTensor,
     doc_lengths: PyTensor,
     device: String,
-    low_memory: bool,
+    index_gpu_memory: String,
 ) -> PyResult<PyLoadedIndex> {
     let main_device = get_device(&device)?;
 
-    // Force document tensors to CPU in low memory mode
-    let storage_device = if low_memory { Device::Cpu } else { main_device };
+    let (codes_device, residuals_device) = match index_gpu_memory.as_str() {
+        "low" => (Device::Cpu, Device::Cpu),
+        "medium" => (main_device, Device::Cpu),
+        "high" => (main_device, main_device),
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "Invalid index_gpu_memory: '{}'. Expected 'low', 'medium' or 'high'.",
+                other
+            )))
+        },
+    };
 
     // Load codec (small tensors)
     let codec = ResidualCodec::load(
@@ -162,15 +171,24 @@ pub fn construct_index(
         _ => None,
     };
 
-    // Load document data (large tensors, may stay on CPU in low memory mode)
-    let doc_lens_t = ensure_tensor(doc_lengths, storage_device, Kind::Int64);
-    let doc_codes_t = ensure_tensor(doc_codes, storage_device, Kind::Int64);
-    let doc_residuals_t = ensure_tensor(doc_residuals, storage_device, Kind::Uint8);
+    // Lengths follow the search device; codes/residuals follow their placement tier.
+    let doc_lens_t = ensure_tensor(doc_lengths, main_device, Kind::Int64);
+    let doc_codes_t = ensure_tensor(doc_codes, codes_device, Kind::Int64);
+    let doc_residuals_t = ensure_tensor(doc_residuals, residuals_device, Kind::Uint8);
 
-    let doc_codes_strided =
-        StridedTensor::new(doc_codes_t, doc_lens_t.shallow_clone(), storage_device);
+    let doc_codes_strided = StridedTensor::new_with_lengths_device(
+        doc_codes_t,
+        doc_lens_t.shallow_clone(),
+        codes_device,
+        main_device,
+    );
 
-    let doc_residuals_strided = StridedTensor::new(doc_residuals_t, doc_lens_t, storage_device);
+    let doc_residuals_strided = StridedTensor::new_with_lengths_device(
+        doc_residuals_t,
+        doc_lens_t,
+        residuals_device,
+        main_device,
+    );
 
     let loaded_index = LoadedIndex {
         codec,

--- a/rust/search/search.rs
+++ b/rust/search/search.rs
@@ -11,6 +11,221 @@ use crate::search::padding::direct_pad_sequences;
 use crate::search::tensor::StridedTensor;
 use crate::utils::residual_codec::ResidualCodec;
 
+/// Fallback per-device workspace budget when the caller does not provide one.
+const DEFAULT_MEMORY_BUDGET_BYTES: i64 = 4 * (1 << 30);
+
+/// Never shrink a stage budget below this during OOM retries.
+const MIN_STAGE_BUDGET_BYTES: i64 = 64 * (1 << 20);
+
+/// Approximate-scoring bytes per padded (doc, token) cell: fp16 score gather + padded copy, plus code gathers.
+fn approx_bytes_per_cell(q_tokens: i64) -> i64 {
+    4 * q_tokens + 32
+}
+
+/// Exact-scoring bytes per padded (doc, token) cell: fp16 token scores plus decompression intermediates and embedding copies.
+fn exact_bytes_per_cell(q_tokens: i64) -> i64 {
+    4 * q_tokens + 1792
+}
+
+fn is_oom_error(error: &anyhow::Error) -> bool {
+    let message = error.to_string().to_lowercase();
+    message.contains("out of memory") || message.contains("cuda oom")
+}
+
+/// Converts panics into errors: tch ops panic on CUDA OOM, and the retry logic needs an `Err` to inspect.
+fn catch_stage_panic(run: impl FnOnce() -> Result<Tensor>) -> Result<Tensor> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(run)) {
+        Ok(result) => result,
+        Err(payload) => {
+            let message = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_else(|| "panic during scoring stage".to_string());
+            Err(anyhow!("{}", message))
+        },
+    }
+}
+
+fn sort_passage_ids_by_doc_length_with_restore(
+    passage_ids: &Tensor,
+    doc_codes_strided: &StridedTensor,
+    device: Device,
+) -> (Tensor, Tensor) {
+    if passage_ids.numel() <= 1 {
+        return (
+            passage_ids.shallow_clone(),
+            Tensor::arange(passage_ids.numel() as i64, (Kind::Int64, device)),
+        );
+    }
+
+    let lengths_device = doc_codes_strided.element_lengths.device();
+    let ids_for_lengths = passage_ids.to_device(lengths_device).to_kind(Kind::Int64);
+    let passage_lengths = doc_codes_strided
+        .element_lengths
+        .index_select(0, &ids_for_lengths);
+    let (_, length_order) = passage_lengths.sort(0, false);
+    let length_order = length_order.to_device(device);
+    let sorted_passage_ids = passage_ids.index_select(0, &length_order);
+    let (_, restore_order) = length_order.sort(0, false);
+
+    (sorted_passage_ids, restore_order)
+}
+
+/// Greedy chunk boundaries over doc lengths keeping each chunk's padded workspace within `budget_bytes`.
+/// Ascending lengths pack short docs densely; otherwise uniform ranges use the global max. Chunks hold >= 1 doc.
+fn plan_chunk_ranges(
+    lengths: &[i64],
+    bytes_per_cell: i64,
+    budget_bytes: i64,
+    lengths_ascending: bool,
+) -> Vec<(i64, i64)> {
+    let n = lengths.len() as i64;
+    if n == 0 {
+        return Vec::new();
+    }
+
+    if !lengths_ascending {
+        let max_len = lengths.iter().copied().max().unwrap_or(1).max(1);
+        let docs_per_chunk = (budget_bytes / (max_len * bytes_per_cell)).max(1);
+        return (0..n)
+            .step_by(docs_per_chunk as usize)
+            .map(|start| (start, docs_per_chunk.min(n - start)))
+            .collect();
+    }
+
+    let mut ranges = Vec::new();
+    let mut start: i64 = 0;
+    while start < n {
+        let mut len: i64 = 1;
+        let mut token_sum: i128 = lengths[start as usize].max(1) as i128;
+        while start + len < n {
+            let chunk_max = lengths[(start + len) as usize].max(1);
+            let padded = (len + 1) as i128 * chunk_max as i128;
+            // Break on budget, or when padding would exceed 2x the true tokens (skewed lengths).
+            if padded * bytes_per_cell as i128 > budget_bytes as i128
+                || padded > 2 * (token_sum + chunk_max as i128)
+            {
+                break;
+            }
+            token_sum += chunk_max as i128;
+            len += 1;
+        }
+        ranges.push((start, len));
+        start += len;
+    }
+    ranges
+}
+
+/// Scores candidates chunk-by-chunk within a memory budget, or in fixed `manual_docs`-sized
+/// chunks when positive. Returned scores are always aligned with the input `ids` order.
+#[allow(clippy::too_many_arguments)]
+fn run_scoring_stage(
+    ids: &Tensor,
+    lengths_cpu: &[i64],
+    bytes_per_cell: i64,
+    budget_bytes: i64,
+    manual_docs: i64,
+    doc_codes_strided: &StridedTensor,
+    device: Device,
+    sort_enabled: bool,
+    score_chunk: &mut dyn FnMut(&Tensor) -> Result<Tensor>,
+) -> Result<Tensor> {
+    let n = ids.size()[0];
+    if n == 0 {
+        return Ok(Tensor::empty(&[0], (Kind::Float, device)));
+    }
+
+    let max_len = lengths_cpu.iter().copied().max().unwrap_or(1).max(1);
+    let padded_cells = n as i128 * max_len as i128;
+    let token_sum: i128 = lengths_cpu.iter().map(|&l| l.max(1) as i128).sum();
+    // Single unsorted chunk only when it fits the budget and padding stays tight.
+    if manual_docs <= 0
+        && padded_cells * bytes_per_cell as i128 <= budget_bytes as i128
+        && padded_cells <= 2 * token_sum
+    {
+        return score_chunk(ids);
+    }
+
+    let (ids_exec, restore_order) = if sort_enabled {
+        let (sorted_ids, restore) =
+            sort_passage_ids_by_doc_length_with_restore(ids, doc_codes_strided, device);
+        (sorted_ids, Some(restore))
+    } else {
+        (ids.shallow_clone(), None)
+    };
+
+    let ranges: Vec<(i64, i64)> = if manual_docs > 0 {
+        (0..n)
+            .step_by(manual_docs as usize)
+            .map(|start| (start, manual_docs.min(n - start)))
+            .collect()
+    } else {
+        let mut planned_lengths = lengths_cpu.to_vec();
+        if sort_enabled {
+            planned_lengths.sort_unstable();
+        }
+        plan_chunk_ranges(&planned_lengths, bytes_per_cell, budget_bytes, sort_enabled)
+    };
+
+    let mut score_chunks = Vec::with_capacity(ranges.len());
+    for (start, len) in ranges {
+        let batch_ids = ids_exec.narrow(0, start, len);
+        score_chunks.push(score_chunk(&batch_ids)?);
+    }
+
+    let mut scores = Tensor::cat(&score_chunks, 0);
+    if let Some(restore) = restore_order {
+        scores = scores.index_select(0, &restore);
+    }
+    Ok(scores)
+}
+
+/// Runs a scoring stage, halving the budget and retrying on CUDA OOM; manual chunk sizes
+/// are respected verbatim, so their OOM errors propagate.
+#[allow(clippy::too_many_arguments)]
+fn run_scoring_stage_with_oom_retry(
+    ids: &Tensor,
+    lengths_cpu: &[i64],
+    bytes_per_cell: i64,
+    budget_bytes: i64,
+    manual_docs: i64,
+    doc_codes_strided: &StridedTensor,
+    device: Device,
+    sort_enabled: bool,
+    score_chunk: &mut dyn FnMut(&Tensor) -> Result<Tensor>,
+) -> Result<Tensor> {
+    let mut budget = budget_bytes.max(MIN_STAGE_BUDGET_BYTES);
+    loop {
+        let attempt = catch_stage_panic(|| {
+            run_scoring_stage(
+                ids,
+                lengths_cpu,
+                bytes_per_cell,
+                budget,
+                manual_docs,
+                doc_codes_strided,
+                device,
+                sort_enabled,
+                score_chunk,
+            )
+        });
+        match attempt {
+            Ok(scores) => return Ok(scores),
+            Err(error)
+                if manual_docs <= 0 && is_oom_error(&error) && budget > MIN_STAGE_BUDGET_BYTES =>
+            {
+                budget = (budget / 2).max(MIN_STAGE_BUDGET_BYTES);
+                eprintln!(
+                    "fast-plaid: scoring stage hit CUDA OOM; retrying with chunk budget {} MiB",
+                    budget / (1 << 20)
+                );
+            },
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 /// Decompresses residual vectors from a packed, quantized format.
 ///
 /// This function reconstructs full embedding vectors by combining coarse centroids with
@@ -171,7 +386,7 @@ impl QueryResultWithTokenScores {
 #[pyclass]
 #[derive(Clone, Debug)]
 pub struct SearchParameters {
-    /// Number of queries per batch.
+    /// Manual docs per scoring chunk; 0 plans chunks from the memory budget.
     #[pyo3(get, set)]
     pub batch_size: usize,
     /// Number of documents to re-rank with exact scores.
@@ -183,20 +398,51 @@ pub struct SearchParameters {
     /// Number of IVF cells to probe during the initial search.
     #[pyo3(get, set)]
     pub n_ivf_probe: usize,
+    /// Per-device scoring workspace budget in bytes. 0 = a conservative default.
+    #[pyo3(get, set)]
+    pub memory_budget_bytes: usize,
 }
 
 #[pymethods]
 impl SearchParameters {
     /// Creates a new `SearchParameters` instance from Python.
     #[new]
-    fn new(batch_size: usize, n_full_scores: usize, top_k: usize, n_ivf_probe: usize) -> Self {
+    #[pyo3(signature = (batch_size, n_full_scores, top_k, n_ivf_probe, memory_budget_bytes=0))]
+    fn new(
+        batch_size: usize,
+        n_full_scores: usize,
+        top_k: usize,
+        n_ivf_probe: usize,
+        memory_budget_bytes: usize,
+    ) -> Self {
         Self {
             batch_size,
             n_full_scores,
             top_k,
             n_ivf_probe,
+            memory_budget_bytes,
         }
     }
+}
+
+fn resolve_memory_budget(params: &SearchParameters) -> i64 {
+    if params.memory_budget_bytes > 0 {
+        params.memory_budget_bytes as i64
+    } else {
+        DEFAULT_MEMORY_BUDGET_BYTES
+    }
+}
+
+/// Computes per-query offsets from packed query lengths.
+fn packed_query_offsets(query_lengths: &[i64]) -> Vec<i64> {
+    let mut offsets = Vec::with_capacity(query_lengths.len() + 1);
+    let mut acc: i64 = 0;
+    offsets.push(0);
+    for len in query_lengths {
+        acc += len;
+        offsets.push(acc);
+    }
+    offsets
 }
 
 /// Processes a batch of queries against the loaded index.
@@ -206,16 +452,18 @@ impl SearchParameters {
 ///
 /// # Arguments
 ///
-/// * `queries` - A 3D tensor of query embeddings with shape `[num_queries, tokens_per_query, dim]`.
+/// * `queries` - A packed 2D tensor of query embeddings with shape `[total_tokens, dim]`,
+///   moved to the device once and viewed per query.
 /// * `index` - The `LoadedIndex` containing all necessary index components.
 /// * `params` - `SearchParameters` for search configuration.
 /// * `device` - The `tch::Device` for computation.
+/// * `show_progress` - Whether to display a progress bar.
 /// * `subset` - An optional list of document ID lists to restrict the search for each query.
+/// * `query_lengths` - True token count per query in the packed tensor.
 ///
 /// # Returns
 ///
-/// A `Result` with a `Vec<QueryResult>`. Individual search failures result in an empty
-/// `QueryResult` for that specific query, ensuring the operation doesn't halt.
+/// A `Result` with a `Vec<QueryResult>`, one per query.
 pub fn search_many(
     queries: &Tensor,
     index: &LoadedIndex,
@@ -223,6 +471,7 @@ pub fn search_many(
     device: Device,
     show_progress: bool,
     subset: Option<Vec<Vec<i64>>>,
+    query_lengths: Vec<i64>,
 ) -> Result<Vec<QueryResult>> {
     let ivf_index = index.ivf_index_strided.as_ref().ok_or_else(|| {
         anyhow!(
@@ -231,15 +480,11 @@ pub fn search_many(
         )
     })?;
 
-    let [num_queries, _, query_dim] = queries.size()[..] else {
-        bail!(
-            "Expected a 3D tensor for queries, but got shape {:?}",
-            queries.size()
-        );
-    };
+    let (num_queries, query_dim, packed_queries, offsets) =
+        prepare_query_layout(queries, &query_lengths, device)?;
 
-    let search_closure = |query_index| {
-        let query_embedding = queries.i(query_index).to(device);
+    let search_closure = |query_index: i64| -> Result<QueryResult> {
+        let query_embedding = get_query_embedding(&packed_queries, &offsets, query_index);
 
         // Handle the per-query subset list
         let query_subset = subset.as_ref().and_then(|s| s.get(query_index as usize));
@@ -257,24 +502,24 @@ pub fn search_many(
             &index.doc_codes_strided,
             &index.doc_residuals_strided,
             params.n_ivf_probe as i64,
-            params.batch_size as i64,
             params.n_full_scores as i64,
             index.nbits,
             params.top_k,
             device,
             subset_tensor.as_ref(),
             false,
-        )
-        .unwrap_or_default();
+            params.batch_size as i64,
+            resolve_memory_budget(params),
+        )?;
 
-        QueryResult {
+        Ok(QueryResult {
             query_id: query_index as usize,
             passage_ids,
             scores,
-        }
+        })
     };
 
-    let results = if show_progress {
+    let results: Result<Vec<QueryResult>> = if show_progress {
         let bar = ProgressBar::new(num_queries.try_into().unwrap());
         (0..num_queries)
             .progress_with(bar)
@@ -284,7 +529,40 @@ pub fn search_many(
         (0..num_queries).map(search_closure).collect()
     };
 
-    Ok(results)
+    results
+}
+
+/// Moves the packed 2D queries to the device, returning `(num_queries, dim, packed, offsets)`.
+fn prepare_query_layout(
+    queries: &Tensor,
+    query_lengths: &[i64],
+    device: Device,
+) -> Result<(i64, i64, Tensor, Vec<i64>)> {
+    let [total_tokens, query_dim] = queries.size()[..] else {
+        bail!(
+            "Expected a 2D packed tensor [total_tokens, dim], got shape {:?}",
+            queries.size()
+        );
+    };
+    let offsets = packed_query_offsets(query_lengths);
+    if *offsets.last().unwrap_or(&0) != total_tokens {
+        bail!(
+            "query_lengths sum ({}) does not match packed token count ({})",
+            offsets.last().unwrap_or(&0),
+            total_tokens
+        );
+    }
+    let mut packed = queries.to_device(device);
+    if packed.kind() != Kind::Half {
+        packed = packed.to_kind(Kind::Half);
+    }
+    Ok((query_lengths.len() as i64, query_dim, packed, offsets))
+}
+
+/// Returns query `query_index` as a zero-copy view into the packed tensor.
+fn get_query_embedding(packed_queries: &Tensor, offsets: &[i64], query_index: i64) -> Tensor {
+    let start = offsets[query_index as usize];
+    packed_queries.narrow(0, start, offsets[query_index as usize + 1] - start)
 }
 
 /// Processes a batch of queries and returns results with token-level similarity matrices.
@@ -298,6 +576,7 @@ pub fn search_many_with_token_scores(
     device: Device,
     show_progress: bool,
     subset: Option<Vec<Vec<i64>>>,
+    query_lengths: Vec<i64>,
 ) -> Result<Vec<QueryResultWithTokenScores>> {
     let ivf_index = index.ivf_index_strided.as_ref().ok_or_else(|| {
         anyhow!(
@@ -306,15 +585,11 @@ pub fn search_many_with_token_scores(
         )
     })?;
 
-    let [num_queries, _, query_dim] = queries.size()[..] else {
-        bail!(
-            "Expected a 3D tensor for queries, but got shape {:?}",
-            queries.size()
-        );
-    };
+    let (num_queries, query_dim, packed_queries, offsets) =
+        prepare_query_layout(queries, &query_lengths, device)?;
 
-    let search_closure = |query_index| {
-        let query_embedding = queries.i(query_index).to(device);
+    let search_closure = |query_index: i64| -> Result<QueryResultWithTokenScores> {
+        let query_embedding = get_query_embedding(&packed_queries, &offsets, query_index);
 
         let query_subset = subset.as_ref().and_then(|s| s.get(query_index as usize));
         let subset_tensor = query_subset.map(|ids| {
@@ -331,25 +606,25 @@ pub fn search_many_with_token_scores(
             &index.doc_codes_strided,
             &index.doc_residuals_strided,
             params.n_ivf_probe as i64,
-            params.batch_size as i64,
             params.n_full_scores as i64,
             index.nbits,
             params.top_k,
             device,
             subset_tensor.as_ref(),
             true,
-        )
-        .unwrap_or_default();
+            params.batch_size as i64,
+            resolve_memory_budget(params),
+        )?;
 
-        QueryResultWithTokenScores {
+        Ok(QueryResultWithTokenScores {
             query_id: query_index as usize,
             passage_ids,
             scores,
             token_scores_inner: token_matrices.unwrap_or_default(),
-        }
+        })
     };
 
-    let results = if show_progress {
+    let results: Result<Vec<QueryResultWithTokenScores>> = if show_progress {
         let bar = ProgressBar::new(num_queries.try_into().unwrap());
         (0..num_queries)
             .progress_with(bar)
@@ -359,22 +634,18 @@ pub fn search_many_with_token_scores(
         (0..num_queries).map(search_closure).collect()
     };
 
-    Ok(results)
+    results
 }
 
 /// Reduces token-level similarity scores into a final document score using the ColBERT MaxSim strategy.
 ///
-/// This function implements the core reduction step of the ColBERT model's scoring mechanism.
-/// It first finds the maximum similarity score for each document token across all query tokens,
-/// effectively ignoring padded tokens in the document. Then, it sums these maximum scores to
-/// produce a single relevance score for each query-document pair in the batch.
-///
-///
+/// Takes ownership of `token_scores` (always freshly materialized by the caller) so the
+/// padding mask can be applied in place instead of allocating a full-size copy.
 ///
 /// # Arguments
 ///
-/// * `token_scores` - A 3D `Tensor` of shape `[batch_size, query_length, doc_length]`
-///   containing the token-level similarity scores.
+/// * `token_scores` - A 3D `Tensor` of shape `[batch_size, doc_length, query_length]`
+///   containing the token-level similarity scores (freshly allocated).
 /// * `attention_mask` - A 2D `Tensor` of shape `[batch_size, doc_length]` where `true`
 ///   indicates a valid token and `false` indicates a padded token.
 ///
@@ -382,17 +653,14 @@ pub fn search_many_with_token_scores(
 ///
 /// A 1D `Tensor` of shape `[batch_size]`, where each element is the final aggregated
 /// ColBERT score for a query-document pair.
-pub fn colbert_score_reduce(token_scores: &Tensor, attention_mask: &Tensor) -> Tensor {
-    let scores_shape = token_scores.size();
+pub fn colbert_score_reduce(token_scores: Tensor, attention_mask: &Tensor) -> Tensor {
+    // Broadcast the document padding mask across query tokens without
+    // materializing a full [batch, doc_len, query_len] boolean tensor.
+    let padding_mask = attention_mask.logical_not().unsqueeze(-1);
 
-    // Expand the document attention mask to match the shape of the token scores.
-    let expanded_mask = attention_mask.unsqueeze(-1).expand(&scores_shape, true);
-
-    // Invert the mask to identify padding positions.
-    let padding_mask = expanded_mask.logical_not();
-
-    // Nullify scores at padded positions by filling them with a large negative number.
-    let masked_scores = token_scores.masked_fill(&padding_mask, -9999.0);
+    // Mask padded positions in place: the tensor is freshly materialized, so no aliasing.
+    let mut token_scores = token_scores;
+    let masked_scores = token_scores.masked_fill_(&padding_mask, -9999.0);
 
     // For each document token, find the maximum similarity score across all query tokens (MaxSim).
     let (max_scores_per_token, _) = masked_scores.max_dim(1, false);
@@ -446,28 +714,33 @@ fn filter_passage_ids_with_subset(passage_ids: &Tensor, subset: &Tensor, device:
 /// 3.  **Re-ranking**: Filters the candidates based on approximate scores, then decompresses the residuals for a smaller subset and computes exact scores.
 /// 4.  **Top-K Selection**: Returns the highest-scoring documents.
 ///
-///
+/// Both scoring stages run in chunks planned from `memory_budget_bytes`, or in fixed
+/// `batch_size`-doc chunks when `batch_size` > 0; chunking is score-preserving
+/// (candidate set, `n_full_scores`, `n_ivf_probe` and `top_k` are unchanged).
 ///
 /// # Arguments
-/// * `query_embeddings` - A tensor containing the query embeddings.
+/// * `query_embeddings` - A 2D tensor `[query_tokens, dim]` holding the query embeddings
+///   (already trimmed of padding and resident on `device` for the packed path).
 /// * `ivf_index_strided` - A strided tensor representing the IVF index for coarse lookup.
 /// * `codec` - The `ResidualCodec` used for decompressing document vectors.
 /// * `embedding_dimension` - The dimensionality of the embeddings.
 /// * `doc_codes_strided` - A strided tensor containing the quantized codes for all documents.
 /// * `doc_residuals_strided` - A strided tensor containing the compressed residuals for all documents.
 /// * `n_ivf_probe` - The number of IVF cells to probe for candidate documents.
-/// * `batch_size` - The batch size used for processing documents during scoring.
 /// * `n_docs_for_full_score` - The number of top documents from the approximate scoring phase to re-rank with full scoring.
 /// * `nbits_param` - The number of bits used in the quantization codec.
 /// * `top_k` - The final number of top results to return.
 /// * `device` - The `tch::Device` (e.g., `Device::Cuda(0)`) on which to perform computations.
 /// * `subset` - An optional tensor of document IDs to restrict the search to.
 /// * `return_token_scores` - If true, also returns per-document token similarity matrices.
+/// * `batch_size` - Manual docs per scoring chunk; 0 plans chunks from the memory budget.
+/// * `memory_budget_bytes` - Per-device scoring workspace budget.
 ///
 /// # Returns
 /// A `Result` containing a tuple of: the top `k` passage IDs (`Vec<i64>`), their
 /// corresponding final scores (`Vec<f32>`), and optionally a list of token similarity
 /// matrices (each of shape `[query_tokens, doc_tokens]`).
+#[allow(clippy::too_many_arguments)]
 pub fn search(
     query_embeddings: &Tensor,
     ivf_index_strided: &StridedTensor,
@@ -476,19 +749,30 @@ pub fn search(
     doc_codes_strided: &StridedTensor,
     doc_residuals_strided: &StridedTensor,
     n_ivf_probe: i64,
-    batch_size: i64,
     n_docs_for_full_score: i64,
     nbits_param: i64,
     top_k: usize,
     device: Device,
     subset: Option<&Tensor>,
     return_token_scores: bool,
+    batch_size: i64,
+    memory_budget_bytes: i64,
 ) -> anyhow::Result<(Vec<i64>, Vec<f32>, Option<Vec<Tensor>>)> {
     let (passage_ids, scores, token_matrices) = tch::no_grad(|| {
+        let q_tokens = query_embeddings.size()[0];
+
         let query_embeddings_unsqueezed = query_embeddings.unsqueeze(0);
 
         // Compute query-centroid scores
         let query_centroid_scores = codec.centroids.matmul(&query_embeddings.transpose(0, 1));
+
+        // The centroid-score matrix stays alive through both stages; deduct it from the planner budget.
+        let num_centroids = codec.centroids.size()[0];
+        let centroid_scores_bytes = num_centroids * q_tokens * 2;
+        let stage_budget =
+            (memory_budget_bytes - centroid_scores_bytes).max(MIN_STAGE_BUDGET_BYTES);
+        // Manual chunking preserves the input order; auto mode sorts candidates by doc length.
+        let sort_enabled = batch_size <= 0;
 
         // Select IVF cells to probe
         let flat_cells_to_probe = if let Some(subset_tensor) = subset {
@@ -550,29 +834,23 @@ pub fn search(
             return Ok((vec![], vec![], None));
         }
 
+        // Candidate doc lengths drive the chunk planner for both stages.
+        let candidate_lengths = doc_codes_strided
+            .element_lengths
+            .index_select(
+                0,
+                &unique_passage_ids.to_device(doc_codes_strided.element_lengths.device()),
+            )
+            .to_device(Device::Cpu);
+        let candidate_lengths_cpu: Vec<i64> = candidate_lengths.try_into()?;
+
         // Approximate scoring using coarse centroids
-        let mut approx_score_chunks = Vec::new();
-        let total_passage_ids_for_approx = unique_passage_ids.size()[0];
-        let num_approx_batches = (total_passage_ids_for_approx + batch_size - 1) / batch_size;
-
-        for step in 0..num_approx_batches {
-            let batch_start = step * batch_size;
-            let batch_end = ((step + 1) * batch_size).min(total_passage_ids_for_approx);
-            if batch_start >= batch_end {
-                continue;
-            }
-
-            let batch_passage_ids =
-                unique_passage_ids.narrow(0, batch_start, batch_end - batch_start);
+        let mut approx_chunk_fn = |batch_ids: &Tensor| -> Result<Tensor> {
             let (batch_packed_codes, batch_doc_lengths) =
-                doc_codes_strided.lookup(&batch_passage_ids, device);
+                doc_codes_strided.lookup(batch_ids, device);
 
             if batch_packed_codes.numel() == 0 {
-                approx_score_chunks.push(Tensor::zeros(
-                    &[batch_passage_ids.size()[0]],
-                    (Kind::Float, device),
-                ));
-                continue;
+                return Ok(Tensor::zeros(&[batch_ids.size()[0]], (Kind::Float, device)));
             }
 
             let batch_approx_scores = query_centroid_scores.index_select(0, &batch_packed_codes);
@@ -580,16 +858,20 @@ pub fn search(
             let (padded_approx_scores, mask) =
                 direct_pad_sequences(&batch_approx_scores, &batch_doc_lengths, 0.0, device)?;
 
-            let padded_approx_scores = colbert_score_reduce(&padded_approx_scores, &mask);
-
-            approx_score_chunks.push(padded_approx_scores);
-        }
-
-        let mut approx_scores = if !approx_score_chunks.is_empty() {
-            Tensor::cat(&approx_score_chunks, 0)
-        } else {
-            Tensor::empty(&[0], (Kind::Float, device))
+            Ok(colbert_score_reduce(padded_approx_scores, &mask))
         };
+
+        let approx_scores = run_scoring_stage_with_oom_retry(
+            &unique_passage_ids,
+            &candidate_lengths_cpu,
+            approx_bytes_per_cell(q_tokens),
+            stage_budget,
+            batch_size,
+            doc_codes_strided,
+            device,
+            sort_enabled,
+            &mut approx_chunk_fn,
+        )?;
 
         if approx_scores.size().get(0) != Some(&unique_passage_ids.size()[0]) {
             return Err(anyhow!(
@@ -601,18 +883,21 @@ pub fn search(
 
         let mut passage_ids_to_rerank = unique_passage_ids;
 
-        // Prune candidates for re-ranking
+        // Prune to n_full_scores, then to the n/4 decompression set.
+        let n_passage_ids_for_decompression = (n_docs_for_full_score / 4).max(1);
         if n_docs_for_full_score < approx_scores.size()[0] && approx_scores.numel() > 0 {
-            let (top_scores, top_indices) =
-                approx_scores.topk(n_docs_for_full_score, 0, true, true);
+            let (_, top_indices) = approx_scores.topk(n_docs_for_full_score, 0, true, true);
 
             passage_ids_to_rerank = passage_ids_to_rerank.index_select(0, &top_indices);
-            approx_scores = top_scores;
-        }
 
-        // Further reduce candidates for decompression
-        let n_passage_ids_for_decompression = (n_docs_for_full_score / 4).max(1);
-        if n_passage_ids_for_decompression < approx_scores.size()[0] && approx_scores.numel() > 0 {
+            // top_indices is sorted by descending score, so the n/4 selection is a narrow.
+            if n_passage_ids_for_decompression < n_docs_for_full_score {
+                passage_ids_to_rerank =
+                    passage_ids_to_rerank.narrow(0, 0, n_passage_ids_for_decompression);
+            }
+        } else if n_passage_ids_for_decompression < approx_scores.size()[0]
+            && approx_scores.numel() > 0
+        {
             let (_, top_indices) =
                 approx_scores.topk(n_passage_ids_for_decompression, 0, true, true);
             passage_ids_to_rerank = passage_ids_to_rerank.index_select(0, &top_indices);
@@ -621,12 +906,6 @@ pub fn search(
         if passage_ids_to_rerank.numel() == 0 {
             return Ok((vec![], vec![], None));
         }
-
-        // Full decompression and exact scoring
-        let (final_codes, final_doc_lengths) =
-            doc_codes_strided.lookup(&passage_ids_to_rerank, device);
-
-        let (final_residuals, _) = doc_residuals_strided.lookup(&passage_ids_to_rerank, device);
 
         let bucket_weights = codec
             .bucket_weights
@@ -637,23 +916,51 @@ pub fn search(
                 anyhow!("Codec missing bucket_weight_indices_lookup for decompression.")
             })?;
 
-        let decompressed_embeddings = decompress_residuals(
-            &final_residuals,
-            bucket_weights,
-            &codec.byte_reversed_bits_map,
-            bucket_weight_indices_lookup,
-            &final_codes,
-            &codec.centroids,
-            embedding_dimension,
-            nbits_param,
-        );
+        // Full decompression and exact scoring, planned like the approximate stage.
+        let rerank_lengths = doc_codes_strided
+            .element_lengths
+            .index_select(
+                0,
+                &passage_ids_to_rerank.to_device(doc_codes_strided.element_lengths.device()),
+            )
+            .to_device(Device::Cpu);
+        let rerank_lengths_cpu: Vec<i64> = rerank_lengths.try_into()?;
 
-        let (padded_doc_embeddings, mask) =
-            direct_pad_sequences(&decompressed_embeddings, &final_doc_lengths, 0.0, device)?;
+        let mut exact_chunk_fn = |batch_ids: &Tensor| -> Result<Tensor> {
+            let (batch_codes, batch_doc_lengths) = doc_codes_strided.lookup(batch_ids, device);
+            let (batch_residuals, _) = doc_residuals_strided.lookup(batch_ids, device);
 
-        let token_scores_3d =
-            padded_doc_embeddings.matmul(&query_embeddings_unsqueezed.transpose(-2, -1));
-        let reduced_scores = colbert_score_reduce(&token_scores_3d, &mask);
+            let decompressed_embeddings = decompress_residuals(
+                &batch_residuals,
+                bucket_weights,
+                &codec.byte_reversed_bits_map,
+                bucket_weight_indices_lookup,
+                &batch_codes,
+                &codec.centroids,
+                embedding_dimension,
+                nbits_param,
+            );
+
+            let (padded_doc_embeddings, mask) =
+                direct_pad_sequences(&decompressed_embeddings, &batch_doc_lengths, 0.0, device)?;
+
+            let token_scores_3d =
+                padded_doc_embeddings.matmul(&query_embeddings_unsqueezed.transpose(-2, -1));
+
+            Ok(colbert_score_reduce(token_scores_3d, &mask))
+        };
+
+        let reduced_scores = run_scoring_stage_with_oom_retry(
+            &passage_ids_to_rerank,
+            &rerank_lengths_cpu,
+            exact_bytes_per_cell(q_tokens),
+            stage_budget,
+            batch_size,
+            doc_codes_strided,
+            device,
+            sort_enabled,
+            &mut exact_chunk_fn,
+        )?;
 
         // Final top-k sort
         let (reduced_scores, sorted_indices) = reduced_scores.sort(0, true);
@@ -664,11 +971,34 @@ pub fn search(
         let reduced_scores: Vec<f32> = reduced_scores.try_into()?;
 
         let result_count = top_k.min(sorted_passage_ids.len());
+        let result_passage_ids = sorted_passage_ids[..result_count].to_vec();
+        let result_scores = reduced_scores[..result_count].to_vec();
 
         let token_matrices = if return_token_scores {
-            let sorted_token_scores = token_scores_3d.index_select(0, &sorted_indices);
-            let sorted_doc_lengths: Vec<i64> =
-                final_doc_lengths.index_select(0, &sorted_indices).try_into()?;
+            let result_passage_ids_tensor = Tensor::from_slice(&result_passage_ids)
+                .to_device(device)
+                .to_kind(Kind::Int64);
+            let (result_codes, result_doc_lengths) =
+                doc_codes_strided.lookup(&result_passage_ids_tensor, device);
+            let (result_residuals, _) =
+                doc_residuals_strided.lookup(&result_passage_ids_tensor, device);
+
+            let result_embeddings = decompress_residuals(
+                &result_residuals,
+                bucket_weights,
+                &codec.byte_reversed_bits_map,
+                bucket_weight_indices_lookup,
+                &result_codes,
+                &codec.centroids,
+                embedding_dimension,
+                nbits_param,
+            );
+
+            let (padded_doc_embeddings, _) =
+                direct_pad_sequences(&result_embeddings, &result_doc_lengths, 0.0, device)?;
+            let sorted_token_scores =
+                padded_doc_embeddings.matmul(&query_embeddings_unsqueezed.transpose(-2, -1));
+            let sorted_doc_lengths: Vec<i64> = result_doc_lengths.try_into()?;
 
             let mut matrices = Vec::with_capacity(result_count);
             for i in 0..result_count {
@@ -685,11 +1015,7 @@ pub fn search(
             None
         };
 
-        Ok((
-            sorted_passage_ids[..result_count].to_vec(),
-            reduced_scores[..result_count].to_vec(),
-            token_matrices,
-        ))
+        Ok((result_passage_ids, result_scores, token_matrices))
     })?;
 
     Ok((passage_ids, scores, token_matrices))

--- a/rust/search/tensor.rs
+++ b/rust/search/tensor.rs
@@ -190,6 +190,22 @@ impl StridedTensor {
         strides
     }
 
+    /// Creates a `StridedTensor` whose (tiny) length tensors live on `lengths_device`, so
+    /// per-query sorting and chunk planning stay on the search device when data is CPU-resident.
+    pub fn new_with_lengths_device(
+        data: Tensor,
+        lengths: Tensor,
+        storage_device: Device,
+        lengths_device: Device,
+    ) -> Self {
+        let mut built = Self::new(data, lengths, storage_device);
+        if lengths_device != storage_device {
+            built.element_lengths = built.element_lengths.to_device(lengths_device);
+            built.cumulative_lengths = built.cumulative_lengths.to_device(lengths_device);
+        }
+        built
+    }
+
     /// Creates a new `StridedTensor`.
     ///
     /// This constructor initializes the structure by preparing the data for efficient
@@ -298,8 +314,10 @@ impl StridedTensor {
     /// A tuple containing the `(data, lengths)` on the `target_device`.
     pub fn lookup(&self, indices: &Tensor, target_device: Device) -> (Tensor, Tensor) {
         let storage_device = self.underlying_data.device();
+        // Length/offset math runs where the lengths live; only the small offsets move for the gather.
+        let lengths_device = self.element_lengths.device();
 
-        let indices_local = indices.to_device(storage_device).to_kind(Kind::Int64);
+        let indices_local = indices.to_device(lengths_device).to_kind(Kind::Int64);
 
         if indices_local.numel() == 0 {
             let mut empty_shape = vec![0];
@@ -342,9 +360,11 @@ impl StridedTensor {
             )
         });
 
-        // Select data and apply mask
-        let strided_data = view.index_select(0, &selected_offsets);
-        let mask = crate::search::tensor::create_mask(&selected_lengths, chosen_stride, None)
+        // Select data and apply mask (on the storage device)
+        let offsets_for_gather = selected_offsets.to_device(storage_device);
+        let lengths_for_mask = selected_lengths.to_device(storage_device);
+        let strided_data = view.index_select(0, &offsets_for_gather);
+        let mask = crate::search::tensor::create_mask(&lengths_for_mask, chosen_stride, None)
             .to_kind(Kind::Bool);
         let final_data = strided_data.index(&[Some(mask)]);
 


### PR DESCRIPTION
## Why
When evaluating popular retrieval benchmarks with long context settings (query/doc lengths of 8192 tokens), some challenges appeared:
* Need to manually reduce/tune default search batch sizes to avoid GPU OOM during search step. There is no single batch_size value that fits every query length, corpus, and GPU.
* Even with tuning, some long context and code benchmarks still OOM during search step. Cause? Exact scoring step materializes big tensors (scales with query tokens x doc tokens) and no chunking of them was configurable/available. The solution was then to implement chunking for those tensors, but enabling it as default was slowing down search time for datasets that do not require it.
* Some datasets such as MLDR OOMed at GPU index load, so `low_memory=True` was needed, but this makes search much slower. The solution was then to manually keep residuals on CPU and only codes on GPU.

All of this tuning overhead justifies implementing auto batching/chunking based on free GPU memory, avoiding possible OOMs with long queries/documents and avoiding slowing down the search step for datasets that do not require it. The same requirements applies for index placement, which is dataset specific and requires placing codes or residuals on CPU/GPU based on available GPU memory. In addition to that, some ops were wasting gpu memory: 3D query tensors may be huge depending on the longest query on the batch, and those could be replaced by packed 2D query tensors; MaxSim scoring creating big tensor copies to mask padded positions, when in-place fill-in was possible. Inside large tensor splitting/chunking, sorting documents before chunking enables minimal padding waste and thus lower gpu memory.

## Summary of all changes

1. Memory-budgeted scoring chunks. Scoring batch/chunk sizes are computed automatically for both scoring stages (approximate and exact rerank) from a per-device memory budget. The default budget is 50% of the free VRAM (`search_memory_fraction=0.5`) at query time (sampled with torch). On CUDA OOM the stage retries with the budget halved. Batching/chunking only kicks in when needed: a single-chunk fast path keeps short queries at full speed, since chunking ops may introduce extra time. If users still want to manually tune it, they can do it forcing a int on `batch_size='auto' | <int>` that will be used as approximate score batch size and exact score chunk size. Sorting is implemented wrt document lengths when chunking is enabled so that minimal padding is used for tensor ops, reducing gpu memory waste and potentially improving speed.
2. Packed query tensors. Queries are passed as one packed 2D tensor plus per-query lengths instead of a padded 3D tensor - no padding memory waste on GPUs and a single host-to-device transfer. query_lengths is now required at the Rust FFI and the padded-3D path is removed; the public Python API is unchanged (packing happens internally).
3. Adaptive index placement. Exposed as `index_gpu_memory='auto' | 'low' | 'medium' | 'high'` (replaces low_memory): 'high' keeps codes and residuals on GPU, 'medium' keeps codes on GPU and residuals (the larger tensor) on CPU, 'low' keeps both on CPU. 'auto' (default) picks the highest tier that keeps total device occupancy within `index_memory_fraction` (default 70% of total VRAM), reserving the rest for the search step.
4. In-place MaxSim masking. The mask fill in MaxSim scoring is applied in place on the freshly materialized score tensor, avoiding an extra full-size GPU allocation.
5. No GPU load in create(). FastPlaid.create() no longer loads the index onto GPU; per-device loads are deferred to the first search, since the object built during creation would be discarded anyway.
6. Per-query search errors now propagate instead of being silently returned as empty results.

## End-to-end benchmark

### Environment

| Component | Version |
|---|---|
| (vanilla) fast-plaid | 1.4.7 |
| (PR) fast-plaid | paulomouraj/fast-plaid `faster-eval-long-context` @ `dd94341` |
| pylate | 1.5.0 |
| mteb | 2.12.25 |
| torch | 2.9.0 (cu128) |
| transformers | 5.3.0 |
| sentence-transformers | 5.3.0 |
| accelerate | 1.13.0 |
| flash-attn | 2.8.3 |
| datasets | 4.8.4 |
| Python | 3.12.13 |
| GPU | 7x NVIDIA H100 80GB per build, driver 580.159.03 |
| Model | lightonai/mLateOn (ColBERT), query/doc length 8192 |

Both builds compiled from source with maturin (release, `LIBTORCH_USE_PYTORCH=1`) against the same
torch; identical eval stack. Search params both sides:
`top_k=1000`, `n_full_scores=8192`, `n_ivf_probe=8`. Vanilla fast-plaid uses PyLate (1.5.0) defaults (+`low_memory=True` for MLDR) while PR fast-plaid uses everything on auto (PR defaults).

### Per-task results (PLAID search step)

| Task | vanilla search (s) | PR search (s) | speedup | vanilla ms/q | PR ms/q | vanilla max mem (GiB) | vanilla mem avg (GiB) | PR mem max (GiB) | PR mem avg (GiB) |
|---|---|---|---|---|---|---|---|---|---|
| MSMARCO | OOM | 1316.8 | — | — | 188.7 | — | — | 51.5 | 51.5 |
| FEVER | OOM | 4001.5 | — | — | 600.3 | — | — | 51.2 | 51.1 |
| ClimateFEVER | OOM | 1597.9 | — | — | 1040.9 | — | — | 51.2 | 51.1 |
| HotpotQA | OOM | 192.5 | — | — | 26.0 | — | — | 28.1 | 28.1 |
| DBPedia | OOM | 54.0 | — | — | 134.9 | — | — | 27.1 | 27.1 |
| NQ | OOM | 33.1 | — | — | 9.6 | — | — | 29.1 | 28.3 |
| QuoraRetrieval | 15.9 | 16.1 | 1.0x | 1.6 | 1.6 | 7.1 | 5.7 | 1.1 | 1.0 |
| CQADupstackRetrieval | OOM (92.6s partial) | 127.5 | — | 11.4 | 9.7 | 46.6 | 30.1 | 8.1 | 4.2 |
| Touche2020 | 6.8 | 9.8 | 0.7x | 139.7 | 199.0 | 70.8 | 66.9 | 13.9 | 13.0 |
| TRECCOVID | OOM | 4.1 | — | — | 81.6 | — | — | 6.2 | 5.4 |
| FiQA2018 | 6.2 | 5.0 | 1.2x | 9.6 | 7.7 | 25.2 | 20.1 | 1.6 | 1.5 |
| SCIDOCS | 8.9 | 6.3 | 1.4x | 8.9 | 6.3 | 28.7 | 22.0 | 1.5 | 1.4 |
| ArguAna | 36.5 | 10.0 | 3.7x | 26.0 | 7.1 | 66.3 | 66.3 | 9.8 | 7.5 |
| SciFact | 3.2 | 3.2 | 1.0x | 10.7 | 10.6 | 2.7 | 2.7 | 1.6 | 1.5 |
| NFCorpus | 3.4 | 3.3 | 1.0x | 10.6 | 10.2 | 2.0 | 2.0 | 1.6 | 1.6 |
| MIRACLRetrievalHardNegatives | OOM | 103.7 | — | — | 9.4 | — | — | 12.4 | 4.0 |
| MultiLongDocRetrieval | OOM (138.2s partial) | 1761.8 | — | 691.1 | 275.3 | 32.2 | 32.1 | 56.0 | 43.6 |
| SyntheticText2SQL | 13.0 | 10.5 | 1.2x | 2.2 | 1.8 | 6.3 | 5.4 | 1.2 | 0.7 |
| CodeFeedbackMT | OOM | 1317.5 | — | — | 99.2 | — | — | 39.5 | 39.2 |
| CodeFeedbackST | OOM | 1049.1 | — | — | 33.5 | — | — | 41.0 | 40.7 |
| COIRCodeSearchNetRetrieval | OOM | 619.8 | — | — | 11.8 | — | — | 47.9 | 38.6 |
| CodeSearchNetCCRetrieval | OOM | 796.0 | — | — | 15.1 | — | — | 40.9 | 37.3 |
| CodeEditSearchRetrieval | 59.5 | 46.3 | 1.3x | 4.6 | 3.6 | 6.9 | 3.1 | 1.7 | 0.4 |
| StackOverflowQA | OOM | 36.1 | — | — | 18.1 | — | — | 36.3 | 34.9 |
| CosQA | 3.0 | 2.9 | 1.1x | 6.1 | 5.8 | 4.5 | 3.9 | 0.6 | 0.6 |
| AppsRetrieval | OOM | 42.8 | — | — | 11.4 | — | — | 13.4 | 11.0 |
| CodeSearchNetRetrieval | OOM | 24.9 | — | — | 4.2 | — | — | 4.6 | 1.2 |
| CodeTransOceanContest | 8.7 | 3.5 | 2.5x | 39.6 | 15.9 | 55.7 | 55.7 | 4.9 | 4.2 |
| CodeTransOceanDL | 6.4 | 2.8 | 2.3x | 35.4 | 15.6 | 51.8 | 51.8 | 5.5 | 5.5 |
| **Total (12 tasks complete on both)** | **172** | **120** | **1.4x** | — | — | — | — | — | — |

Notes:
- **MultiLongDocRetrieval**: vanilla OOMs after first lang (ar);
- **CQADupstackRetrieval**: vanilla covers 8 of 12 subtasks before OOM.
- **Touche2020 (0.7x)** is the single row where PR is slower (6.8s -> 9.8s over 49 queries): planner
  overhead on a tiny query set, but PR uses 13.9 GiB while vanilla peaked at 70.8 GiB.
- Some OOMs on vanilla fast-plaid can be avoided by setting `low_memory=True` (index kept on
CPU, much slower search) and/or lowering the query batch size (PyLate's retriever passes
batches of 50 queries into `search()`; smaller batches shrink every scoring tensor
proportionally, at a large speed cost). Others cannot: on MLDR the OOM occurs in the
exact-scoring step *with `low_memory=True` already set*, and that tensor has a per-query
floor of ~34 GiB (`n_full_scores=8192` candidates × 8192-token docs × 128 dims), no batch
size fixes it, and lowering `n_full_scores` changes retrieval results.


